### PR TITLE
Add donation support links

### DIFF
--- a/app/src/main/java/com/aqua_ix/youbimiku/Constants.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/Constants.kt
@@ -14,6 +14,8 @@ class RemoteConfigKey {
         const val AD_NETWORK = "ad_network"
         const val AD_DISPLAY_REQUEST_TIMES = "ad_display_request_times"
         const val OPENAI_ENABLED = "openai_enabled"
+        const val SUPPORT_LINKS = "support_links"
+        const val SUPPORT_DISPLAY_REQUEST_TIMES = "support_display_request_times"
     }
 
     class AdNetwork {

--- a/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
@@ -1068,10 +1068,12 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
             }
         }
 
+        val supportTimes = remoteConfig.getDouble(RemoteConfigKey.SUPPORT_DISPLAY_REQUEST_TIMES).toInt()
+        if (supportTimes <= 0 || isSupporter(applicationContext)) return
+
         val supportCount = getSupportRequestCount(applicationContext) + 1
         setSupportRequestCount(applicationContext, supportCount)
-        val supportTimes = remoteConfig.getDouble(RemoteConfigKey.SUPPORT_DISPLAY_REQUEST_TIMES).toInt()
-        if (supportTimes > 0 && supportCount >= supportTimes) {
+        if (supportCount >= supportTimes) {
             Log.d(TAG, "Support display request count: $supportCount")
             setSupportRequestCount(applicationContext, 0)
             showSupportDialog(requireUrls = true)

--- a/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
@@ -828,8 +828,9 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
 
     private fun openUrl(url: String) {
         try {
-            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-            startActivity(intent)
+            val uri = Uri.parse(url)
+            if (uri.scheme != "http" && uri.scheme != "https") return
+            startActivity(Intent(Intent.ACTION_VIEW, uri))
         } catch (e: Exception) {
             Toast.makeText(this, getString(R.string.support_url_error), Toast.LENGTH_SHORT).show()
         }

--- a/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
@@ -908,7 +908,7 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
         menu.findItem(R.id.avatar_mode_reload).isVisible = isAvatarMode
 
         val hasSupportLinks = parseSupportLinks(remoteConfig.getString(RemoteConfigKey.SUPPORT_LINKS)).isNotEmpty()
-        menu.findItem(R.id.support_developer).isVisible = hasSupportLinks && !isSupporter(applicationContext)
+        menu.findItem(R.id.support_developer).isVisible = hasSupportLinks
 
         menu.add(Menu.NONE, 1, Menu.NONE, R.string.avatar_mode)
             .setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM)

--- a/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
@@ -859,6 +859,10 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
             val button = android.widget.Button(this).apply {
                 layoutParams = params
                 text = getString(R.string.support_button_label, name)
+                setTextColor(android.graphics.Color.WHITE)
+                backgroundTintList = android.content.res.ColorStateList.valueOf(
+                    androidx.core.content.ContextCompat.getColor(context, R.color.colorPrimary)
+                )
                 setOnClickListener { openUrl(url); dialog.dismiss() }
             }
             container.addView(button)

--- a/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
@@ -906,6 +906,9 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
 
         menu.findItem(R.id.avatar_mode_reload).isVisible = isAvatarMode
 
+        val hasSupportLinks = parseSupportLinks(remoteConfig.getString(RemoteConfigKey.SUPPORT_LINKS)).isNotEmpty()
+        menu.findItem(R.id.support_developer).isVisible = hasSupportLinks && !isSupporter(applicationContext)
+
         menu.add(Menu.NONE, 1, Menu.NONE, R.string.avatar_mode)
             .setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM)
 

--- a/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
@@ -837,8 +837,6 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
     }
 
     private fun showSupportDialog(requireUrls: Boolean = false) {
-        if (isSupporter(applicationContext)) return
-
         val linksJson = remoteConfig.getString(RemoteConfigKey.SUPPORT_LINKS)
         val links = parseSupportLinks(linksJson)
 

--- a/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
@@ -58,10 +58,14 @@ import com.aqua_ix.youbimiku.config.getDisplayName
 import com.aqua_ix.youbimiku.config.getFontSizeType
 import com.aqua_ix.youbimiku.config.getLanguage
 import com.aqua_ix.youbimiku.config.getOpenAIRequestCount
+import com.aqua_ix.youbimiku.config.getSupportRequestCount
 import com.aqua_ix.youbimiku.config.getUIMode
+import com.aqua_ix.youbimiku.config.isSupporter
 import com.aqua_ix.youbimiku.config.setAIModel
 import com.aqua_ix.youbimiku.config.setFontSize
 import com.aqua_ix.youbimiku.config.setOpenAIRequestCount
+import com.aqua_ix.youbimiku.config.setSupporter
+import com.aqua_ix.youbimiku.config.setSupportRequestCount
 import com.aqua_ix.youbimiku.config.setUIMode
 import com.aqua_ix.youbimiku.database.AppDatabase
 import com.aqua_ix.youbimiku.database.entityToMessage
@@ -822,6 +826,67 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
         }
     }
 
+    private fun openUrl(url: String) {
+        try {
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+            startActivity(intent)
+        } catch (e: Exception) {
+            Toast.makeText(this, getString(R.string.support_url_error), Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun showSupportDialog(requireUrls: Boolean = false) {
+        if (isSupporter(applicationContext)) return
+
+        val linksJson = remoteConfig.getString(RemoteConfigKey.SUPPORT_LINKS)
+        val links = parseSupportLinks(linksJson)
+
+        if (requireUrls && links.isEmpty()) return
+
+        val view = layoutInflater.inflate(R.layout.dialog_support, null)
+        val dialog = AlertDialog.Builder(this)
+            .setView(view)
+            .setNegativeButton(R.string.support_later, null)
+            .create()
+
+        val container = view.findViewById<android.widget.LinearLayout>(R.id.support_buttons_container)
+        val params = android.widget.LinearLayout.LayoutParams(
+            android.widget.LinearLayout.LayoutParams.MATCH_PARENT,
+            resources.getDimensionPixelSize(R.dimen.support_button_height)
+        ).also { it.bottomMargin = resources.getDimensionPixelSize(R.dimen.support_button_margin) }
+
+        links.forEach { (name, url) ->
+            val button = android.widget.Button(this).apply {
+                layoutParams = params
+                text = getString(R.string.support_button_label, name)
+                setOnClickListener { openUrl(url); dialog.dismiss() }
+            }
+            container.addView(button)
+        }
+
+        view.findViewById<android.widget.Button>(R.id.btn_already_supporting).setOnClickListener {
+            setSupporter(applicationContext)
+            dialog.dismiss()
+        }
+
+        dialog.show()
+    }
+
+    private fun parseSupportLinks(json: String): List<Pair<String, String>> {
+        return try {
+            val array = org.json.JSONArray(json)
+            (0 until array.length()).mapNotNull { i ->
+                val obj = array.getJSONObject(i)
+                val name = obj.optString("name")
+                val url = obj.optString("url")
+                if (name.isNotEmpty() && url.isNotEmpty()) name to url else null
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to parse support_links: ${e.message}")
+            emptyList()
+        }
+    }
+
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         val inflater = menuInflater
         inflater.inflate(R.menu.menu, menu)
@@ -893,6 +958,11 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
 
             R.id.setting_official_account -> {
                 openOfficialAccountIntent()
+                true
+            }
+
+            R.id.support_developer -> {
+                showSupportDialog()
                 true
             }
 
@@ -988,6 +1058,15 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
                     setOpenAIRequestCount(applicationContext, 0)
                 }
             }
+        }
+
+        val supportCount = getSupportRequestCount(applicationContext) + 1
+        setSupportRequestCount(applicationContext, supportCount)
+        val supportTimes = remoteConfig.getDouble(RemoteConfigKey.SUPPORT_DISPLAY_REQUEST_TIMES).toInt()
+        if (supportTimes > 0 && supportCount >= supportTimes) {
+            Log.d(TAG, "Support display request count: $supportCount")
+            setSupportRequestCount(applicationContext, 0)
+            showSupportDialog(requireUrls = true)
         }
     }
 

--- a/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
@@ -863,6 +863,7 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
             val button = android.widget.Button(this).apply {
                 layoutParams = params
                 text = getString(R.string.support_button_label, name)
+                isAllCaps = false
                 setTextColor(android.graphics.Color.WHITE)
                 backgroundTintList = android.content.res.ColorStateList.valueOf(
                     androidx.core.content.ContextCompat.getColor(context, R.color.colorPrimary)

--- a/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
@@ -847,6 +847,10 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
         val dialog = AlertDialog.Builder(this)
             .setView(view)
             .setNegativeButton(R.string.support_later, null)
+            .setNeutralButton(R.string.support_already) { _, _ ->
+                setSupporter(applicationContext)
+                invalidateOptionsMenu()
+            }
             .create()
 
         val container = view.findViewById<android.widget.LinearLayout>(R.id.support_buttons_container)
@@ -866,11 +870,6 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
                 setOnClickListener { openUrl(url); dialog.dismiss() }
             }
             container.addView(button)
-        }
-
-        view.findViewById<android.widget.Button>(R.id.btn_already_supporting).setOnClickListener {
-            setSupporter(applicationContext)
-            dialog.dismiss()
         }
 
         dialog.show()

--- a/app/src/main/java/com/aqua_ix/youbimiku/config/OpenAIConfig.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/config/OpenAIConfig.kt
@@ -17,3 +17,27 @@ fun setOpenAIRequestCount(context: Context, count: Int) {
         count
     )
 }
+
+fun getSupportRequestCount(context: Context): Int {
+    return SharedPreferenceManager.get(
+        context,
+        Key.SUPPORT_REQUEST_COUNT.name,
+        0
+    )
+}
+
+fun setSupportRequestCount(context: Context, count: Int) {
+    return SharedPreferenceManager.put(
+        context,
+        Key.SUPPORT_REQUEST_COUNT.name,
+        count
+    )
+}
+
+fun isSupporter(context: Context): Boolean {
+    return SharedPreferenceManager.get(context, Key.IS_SUPPORTER.name, false)
+}
+
+fun setSupporter(context: Context) {
+    SharedPreferenceManager.put(context, Key.IS_SUPPORTER.name, true)
+}

--- a/app/src/main/java/com/aqua_ix/youbimiku/config/OpenAIConfig.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/config/OpenAIConfig.kt
@@ -17,27 +17,3 @@ fun setOpenAIRequestCount(context: Context, count: Int) {
         count
     )
 }
-
-fun getSupportRequestCount(context: Context): Int {
-    return SharedPreferenceManager.get(
-        context,
-        Key.SUPPORT_REQUEST_COUNT.name,
-        0
-    )
-}
-
-fun setSupportRequestCount(context: Context, count: Int) {
-    return SharedPreferenceManager.put(
-        context,
-        Key.SUPPORT_REQUEST_COUNT.name,
-        count
-    )
-}
-
-fun isSupporter(context: Context): Boolean {
-    return SharedPreferenceManager.get(context, Key.IS_SUPPORTER.name, false)
-}
-
-fun setSupporter(context: Context) {
-    SharedPreferenceManager.put(context, Key.IS_SUPPORTER.name, true)
-}

--- a/app/src/main/java/com/aqua_ix/youbimiku/config/SharedPreferenceManager.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/config/SharedPreferenceManager.kt
@@ -27,6 +27,14 @@ open class SharedPreferenceManager {
         fun put(context: Context, key: String, value: Int) {
             instance(context).edit().putInt(key, value).apply()
         }
+
+        fun get(context: Context, key: String, defValue: Boolean): Boolean {
+            return instance(context).getBoolean(key, defValue)
+        }
+
+        fun put(context: Context, key: String, value: Boolean) {
+            instance(context).edit().putBoolean(key, value).apply()
+        }
     }
 }
 
@@ -37,5 +45,7 @@ enum class Key {
     LAUNCH_COUNT,
     AI_MODEL,
     OPENAI_REQUEST_COUNT,
+    SUPPORT_REQUEST_COUNT,
+    IS_SUPPORTER,
     UI_MODE
 }

--- a/app/src/main/java/com/aqua_ix/youbimiku/config/SupportConfig.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/config/SupportConfig.kt
@@ -1,0 +1,27 @@
+package com.aqua_ix.youbimiku.config
+
+import android.content.Context
+
+fun getSupportRequestCount(context: Context): Int {
+    return SharedPreferenceManager.get(
+        context,
+        Key.SUPPORT_REQUEST_COUNT.name,
+        0
+    )
+}
+
+fun setSupportRequestCount(context: Context, count: Int) {
+    return SharedPreferenceManager.put(
+        context,
+        Key.SUPPORT_REQUEST_COUNT.name,
+        count
+    )
+}
+
+fun isSupporter(context: Context): Boolean {
+    return SharedPreferenceManager.get(context, Key.IS_SUPPORTER.name, false)
+}
+
+fun setSupporter(context: Context) {
+    SharedPreferenceManager.put(context, Key.IS_SUPPORTER.name, true)
+}

--- a/app/src/main/res/layout/dialog_support.xml
+++ b/app/src/main/res/layout/dialog_support.xml
@@ -2,56 +2,35 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:paddingHorizontal="24dp"
+    android:paddingTop="24dp"
+    android:paddingBottom="8dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/support_title"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        android:textColor="?attr/colorPrimary"
+        android:gravity="center"
+        android:layout_marginBottom="8dp" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/support_description"
+        android:textSize="13sp"
+        android:textColor="?android:attr/textColorSecondary"
+        android:gravity="center"
+        android:lineSpacingMultiplier="1.3"
+        android:layout_marginBottom="20dp" />
 
     <LinearLayout
+        android:id="@+id/support_buttons_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:paddingHorizontal="24dp"
-        android:paddingTop="24dp"
-        android:paddingBottom="16dp">
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/support_title"
-            android:textSize="18sp"
-            android:textStyle="bold"
-            android:textColor="?attr/colorPrimary"
-            android:gravity="center"
-            android:layout_marginBottom="8dp" />
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/support_description"
-            android:textSize="13sp"
-            android:textColor="?android:attr/textColorSecondary"
-            android:gravity="center"
-            android:lineSpacingMultiplier="1.3"
-            android:layout_marginBottom="20dp" />
-
-        <LinearLayout
-            android:id="@+id/support_buttons_container"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical" />
-
-    </LinearLayout>
-
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="?android:attr/listDivider" />
-
-    <Button
-        android:id="@+id/btn_already_supporting"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/support_already"
-        style="?attr/borderlessButtonStyle"
-        android:textSize="12sp"
-        android:textColor="?android:attr/textColorSecondary" />
+        android:orientation="vertical" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_support.xml
+++ b/app/src/main/res/layout/dialog_support.xml
@@ -3,7 +3,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:paddingHorizontal="24dp"
+    android:paddingStart="24dp"
+    android:paddingEnd="24dp"
     android:paddingTop="24dp"
     android:paddingBottom="8dp">
 

--- a/app/src/main/res/layout/dialog_support.xml
+++ b/app/src/main/res/layout/dialog_support.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/support_title"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        android:gravity="center"
+        android:layout_marginBottom="8dp" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/support_description"
+        android:textSize="14sp"
+        android:gravity="center"
+        android:layout_marginBottom="20dp" />
+
+    <LinearLayout
+        android:id="@+id/support_buttons_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical" />
+
+    <Button
+        android:id="@+id/btn_already_supporting"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/support_already"
+        style="?attr/borderlessButtonStyle"
+        android:textSize="12sp"
+        android:layout_marginTop="4dp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_support.xml
+++ b/app/src/main/res/layout/dialog_support.xml
@@ -2,31 +2,48 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:padding="24dp">
-
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/support_title"
-        android:textSize="20sp"
-        android:textStyle="bold"
-        android:gravity="center"
-        android:layout_marginBottom="8dp" />
-
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/support_description"
-        android:textSize="14sp"
-        android:gravity="center"
-        android:layout_marginBottom="20dp" />
+    android:orientation="vertical">
 
     <LinearLayout
-        android:id="@+id/support_buttons_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical" />
+        android:orientation="vertical"
+        android:paddingHorizontal="24dp"
+        android:paddingTop="24dp"
+        android:paddingBottom="16dp">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/support_title"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:textColor="?attr/colorPrimary"
+            android:gravity="center"
+            android:layout_marginBottom="8dp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/support_description"
+            android:textSize="13sp"
+            android:textColor="?android:attr/textColorSecondary"
+            android:gravity="center"
+            android:lineSpacingMultiplier="1.3"
+            android:layout_marginBottom="20dp" />
+
+        <LinearLayout
+            android:id="@+id/support_buttons_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
+
+    </LinearLayout>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="?android:attr/listDivider" />
 
     <Button
         android:id="@+id/btn_already_supporting"
@@ -35,6 +52,6 @@
         android:text="@string/support_already"
         style="?attr/borderlessButtonStyle"
         android:textSize="12sp"
-        android:layout_marginTop="4dp" />
+        android:textColor="?android:attr/textColorSecondary" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_support.xml
+++ b/app/src/main/res/layout/dialog_support.xml
@@ -28,10 +28,16 @@
         android:lineSpacingMultiplier="1.3"
         android:layout_marginBottom="20dp" />
 
-    <LinearLayout
-        android:id="@+id/support_buttons_container"
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical" />
+        android:layout_height="wrap_content">
+
+        <LinearLayout
+            android:id="@+id/support_buttons_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
+
+    </ScrollView>
 
 </LinearLayout>

--- a/app/src/main/res/menu/menu.xml
+++ b/app/src/main/res/menu/menu.xml
@@ -15,4 +15,6 @@
         android:title="@string/avatar_mode_reload" />
     <item android:id="@+id/setting_official_account"
         android:title="@string/official_account"/>
+    <item android:id="@+id/support_developer"
+        android:title="@string/support_menu_title"/>
 </menu>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -69,6 +69,6 @@
     <string name="support_description">アプリを楽しんでいただけていたら、ぜひ開発の継続を応援してください！</string>
     <string name="support_button_label">%sで支援する</string>
     <string name="support_later">後で</string>
-    <string name="support_already">すでに支援しています ♥</string>
+    <string name="support_already">すでに支援しています</string>
     <string name="support_url_error">ブラウザが見つかりません</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -63,4 +63,12 @@
     <string name="avatar_mode_message_accept">使ってみる</string>
     <string name="avatar_mode_message_cancel">閉じる</string>
     <string name="avatar_mode_reload">再読み込み</string>
+
+    <string name="support_menu_title">開発者を応援する</string>
+    <string name="support_title">♥ ミクを応援しよう！</string>
+    <string name="support_description">アプリを楽しんでいただけている方は、ぜひ開発を応援してください！</string>
+    <string name="support_button_label">%sで支援する</string>
+    <string name="support_later">後で</string>
+    <string name="support_already">すでに支援しています ♥</string>
+    <string name="support_url_error">ブラウザが見つかりません</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -65,8 +65,8 @@
     <string name="avatar_mode_reload">再読み込み</string>
 
     <string name="support_menu_title">開発者を応援する</string>
-    <string name="support_title">♥ ミクを応援しよう！</string>
-    <string name="support_description">アプリを楽しんでいただけている方は、ぜひ開発を応援してください！</string>
+    <string name="support_title">開発を支援する</string>
+    <string name="support_description">アプリを楽しんでいただけていたら、ぜひ開発の継続を応援してください！</string>
     <string name="support_button_label">%sで支援する</string>
     <string name="support_later">後で</string>
     <string name="support_already">すでに支援しています ♥</string>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="dp_19">19dp</dimen>
+    <dimen name="support_button_height">48dp</dimen>
+    <dimen name="support_button_margin">10dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,8 +66,8 @@
     <string name="avatar_mode_reload">Reload</string>
 
     <string name="support_menu_title">Support Developer</string>
-    <string name="support_title">&#9829; Support Miku!</string>
-    <string name="support_description">If you enjoy this app, please consider supporting development!</string>
+    <string name="support_title">Support Development</string>
+    <string name="support_description">Help keep this app going! Your support is greatly appreciated.</string>
     <string name="support_button_label">Support on %s</string>
     <string name="support_later">Later</string>
     <string name="support_already">I\'m already supporting ♥</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,6 +70,6 @@
     <string name="support_description">Help keep this app going! Your support is greatly appreciated.</string>
     <string name="support_button_label">Support on %s</string>
     <string name="support_later">Later</string>
-    <string name="support_already">I\'m already supporting ♥</string>
+    <string name="support_already">I\'m already supporting</string>
     <string name="support_url_error">Browser not found</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,4 +64,12 @@
     <string name="avatar_mode_message_accept">Try Avatar Mode</string>
     <string name="avatar_mode_message_cancel">Not Now</string>
     <string name="avatar_mode_reload">Reload</string>
+
+    <string name="support_menu_title">Support Developer</string>
+    <string name="support_title">&#9829; Support Miku!</string>
+    <string name="support_description">If you enjoy this app, please consider supporting development!</string>
+    <string name="support_button_label">Support on %s</string>
+    <string name="support_later">Later</string>
+    <string name="support_already">I\'m already supporting ♥</string>
+    <string name="support_url_error">Browser not found</string>
 </resources>

--- a/app/src/main/res/xml/remote_config_defaults.xml
+++ b/app/src/main/res/xml/remote_config_defaults.xml
@@ -26,6 +26,6 @@
     </entry>
     <entry>
         <key>support_display_request_times</key>
-        <value>50</value>
+        <value>30</value>
     </entry>
 </defaultsMap>

--- a/app/src/main/res/xml/remote_config_defaults.xml
+++ b/app/src/main/res/xml/remote_config_defaults.xml
@@ -20,4 +20,12 @@
         <key>openai_enabled</key>
         <value>true</value>
     </entry>
+    <entry>
+        <key>support_links</key>
+        <value>[]</value>
+    </entry>
+    <entry>
+        <key>support_display_request_times</key>
+        <value>50</value>
+    </entry>
 </defaultsMap>


### PR DESCRIPTION
## 変更概要

投げ銭リンク（Patreon / Ko-fi / GitHub Sponsors 等）をアプリ内に設置する機能を追加。

- **RemoteConfig管理**: `support_links` キー（JSON配列）でサービス名・URLを管理。リポジトリにURLを埋め込まない
- **ダイアログ**: JSON配列の要素数に応じてボタンを動的生成。種類・数を固定しない
- **動線**: オーバーフローメニューから常時アクセス可能 + 一定メッセージ数ごとに自動表示（`support_display_request_times` で頻度調整）
- **サポーター除外**: 「すでに支援しています」ボタンでフラグを保存し、以降のダイアログ表示をスキップ

### RemoteConfig設定例
```json
[
  {"name": "Patreon", "url": "https://patreon.com/xxx"},
  {"name": "Ko-fi",   "url": "https://ko-fi.com/xxx"}
]
```

## 制限事項

- 外部サービスでの支援完了を自動検証できないため、サポーター判定はセルフレポート方式（ユーザーの自己申告）

## 動作確認

- [ ] メニューからダイアログが表示される
- [ ] RemoteConfig に `support_links` を設定するとボタンが表示される
- [ ] 「すでに支援しています」タップ後、ダイアログが表示されなくなる
- [ ] N メッセージ後に自動表示される