### PR TITLE
アバターモードのWebViewライフサイクルと権限処理を修正

### DIFF
--- a/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
@@ -1126,9 +1126,10 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
     public override fun onPause() {
         isActivityResumed = false
         if (::webView.isInitialized) {
-            // バックグラウンドで音声再生や3D描画が続かないように止める
+            // バックグラウンドで音声再生や3D描画が続かないように止める。
+            // WebView.pauseTimers() はプロセス内の全WebViewのタイマーを止めてしまうので使わない。
+            // インタースティシャル広告のWebViewまで凍結され、閉じるボタンが出なくなる。
             webView.onPause()
-            webView.pauseTimers()
         }
         adController.onPause(this)
         super.onPause()
@@ -1138,7 +1139,6 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
         isActivityResumed = true
         adController.onResume(this)
         if (::webView.isInitialized) {
-            webView.resumeTimers()
             webView.onResume()
         }
         super.onResume()

--- a/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
@@ -23,6 +23,7 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
@@ -103,6 +104,8 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
     private lateinit var avatarClientId: String
     private lateinit var avatarClientSecret: String
 
+    private var pendingAudioPermissionRequest: PermissionRequest? = null
+
     private var openAIPreviousResponse = ""
 
     private val job = SupervisorJob()
@@ -113,8 +116,27 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
     private val scope = CoroutineScope(Dispatchers.Default + job + exceptionHandler)
     private var openAITaskJob: Job? = null
 
-    private var PERMISSIONS_REQUEST_RECORD_AUDIO = 0
     private var actionBarSize = 0
+
+    private val recordAudioPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            val request = pendingAudioPermissionRequest
+            pendingAudioPermissionRequest = null
+            if (isGranted) {
+                if (request != null) {
+                    request.grant(arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE))
+                } else {
+                    webView.reload()
+                }
+            } else {
+                request?.deny()
+                Toast.makeText(
+                    this,
+                    R.string.avatar_mode_needs_record_audio_permission,
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
+        }
 
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -532,10 +554,8 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
                         if (checkSelfPermission(android.Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED) {
                             request.grant(arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE))
                         } else {
-                            requestPermissions(
-                                arrayOf(android.Manifest.permission.RECORD_AUDIO),
-                                PERMISSIONS_REQUEST_RECORD_AUDIO
-                            )
+                            pendingAudioPermissionRequest = request
+                            recordAudioPermissionLauncher.launch(android.Manifest.permission.RECORD_AUDIO)
                         }
                         return
                     }
@@ -975,27 +995,6 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
                 binding.chatView.receive(receivedMessage)
             }
             appDatabase.messageDao().insert(messageToEntity(receivedMessage))
-        }
-    }
-
-    override fun onRequestPermissionsResult(
-        requestCode: Int,
-        permissions: Array<out String>,
-        grantResults: IntArray
-    ) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        when (requestCode) {
-            PERMISSIONS_REQUEST_RECORD_AUDIO -> {
-                if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    webView.reload()
-                } else if (grantResults[0] == PackageManager.PERMISSION_DENIED) {
-                    Toast.makeText(
-                        this,
-                        R.string.avatar_mode_needs_record_audio_permission,
-                        Toast.LENGTH_SHORT
-                    ).show()
-                }
-            }
         }
     }
 

--- a/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
@@ -108,6 +108,10 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
 
     // 認証情報の到着を待っているアバターモードへの切り替え要求
     private var pendingAvatarMode = false
+
+    // 認証情報の取得結果が空だったかどうか。値が変わらない限りリスナーは再発火しないので、
+    // この場合は到着を待たずにエラーにする
+    private var avatarCredentialsFailed = false
     private var pendingAudioPermissionRequest: PermissionRequest? = null
 
     // プロセス再生成前に開いていたアバターページ。次にアバターページを開くときに一度だけ使う
@@ -460,10 +464,12 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
 
                 if (avatarClientId.isEmpty() || avatarClientSecret.isEmpty()) {
                     Log.e(TAG, "Avatar credentials are missing.")
+                    avatarCredentialsFailed = true
                     onAvatarCredentialsUnavailable()
                     return
                 }
 
+                avatarCredentialsFailed = false
                 if (pendingAvatarMode) {
                     // 認証情報の到着を待っていた切り替え要求を再開する
                     pendingAvatarMode = false
@@ -475,6 +481,7 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
 
             override fun onCancelled(databaseError: DatabaseError) {
                 Log.e(TAG, "Database error: ${databaseError.message}")
+                avatarCredentialsFailed = true
                 onAvatarCredentialsUnavailable()
             }
         })
@@ -943,6 +950,13 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
 
     private fun toggleAvatarMode(enable: Boolean = !isAvatarMode) {
         if (enable && (avatarClientId.isEmpty() || avatarClientSecret.isEmpty())) {
+            if (avatarCredentialsFailed) {
+                // 取得結果が空だった場合は待っても届かないので、その場でエラーにする
+                Log.e(TAG, "Avatar credentials are unavailable.")
+                Toast.makeText(this, R.string.avatar_mode_error, Toast.LENGTH_SHORT).show()
+                return
+            }
+
             // 認証情報がまだ届いていないので、待っていることを示して到着後に切り替える
             Log.w(TAG, "Avatar credentials are not ready yet.")
             pendingAvatarMode = true

--- a/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
@@ -144,8 +144,13 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
     private val avatarModeBackCallback = object : OnBackPressedCallback(false) {
         override fun handleOnBackPressed() {
             val backForwardList = webView.copyBackForwardList()
-            val previous = backForwardList.getItemAtIndex(backForwardList.currentIndex - 1)
-            if (webView.canGoBack() && previous?.url?.startsWith(BuildConfig.AVATAR_BASE_URL) == true) {
+            val previousIndex = backForwardList.currentIndex - 1
+            val previousUrl = if (webView.canGoBack() && previousIndex >= 0) {
+                backForwardList.getItemAtIndex(previousIndex)?.url
+            } else {
+                null
+            }
+            if (previousUrl?.startsWith(BuildConfig.AVATAR_BASE_URL) == true) {
                 // アバターページ内の履歴を辿る
                 webView.goBack()
             } else {

--- a/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
@@ -1000,6 +1000,11 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
 
     public override fun onPause() {
         isActivityResumed = false
+        if (::webView.isInitialized) {
+            // バックグラウンドで音声再生や3D描画が続かないように止める
+            webView.onPause()
+            webView.pauseTimers()
+        }
         adController.onPause(this)
         super.onPause()
     }
@@ -1007,10 +1012,19 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
     public override fun onResume() {
         isActivityResumed = true
         adController.onResume(this)
+        if (::webView.isInitialized) {
+            webView.resumeTimers()
+            webView.onResume()
+        }
         super.onResume()
     }
 
     public override fun onDestroy() {
+        if (::webView.isInitialized) {
+            webView.stopLoading()
+            (webView.parent as? ViewGroup)?.removeView(webView)
+            webView.destroy()
+        }
         detectIntent.resetContexts()
         scope.coroutineContext.cancel()
         adController.onDestroy(this)

--- a/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
@@ -102,9 +102,11 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
     private var isActivityResumed = false
 
     private lateinit var webView: WebView
-    private lateinit var avatarClientId: String
-    private lateinit var avatarClientSecret: String
+    private var avatarClientId = ""
+    private var avatarClientSecret = ""
 
+    // 認証情報の到着を待っているアバターモードへの切り替え要求
+    private var pendingAvatarMode = false
     private var pendingAudioPermissionRequest: PermissionRequest? = null
 
     private var openAIPreviousResponse = ""
@@ -444,16 +446,35 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
                 avatarClientSecret =
                     dataSnapshot.child("clientSecret").getValue(String::class.java) ?: ""
 
-                if (getUIMode(this@MainActivity) != "") {
-                    isAvatarMode = getUIMode(this@MainActivity) == UIModeConfig.AVATAR.name
-                    toggleAvatarMode(isAvatarMode)
+                if (avatarClientId.isEmpty() || avatarClientSecret.isEmpty()) {
+                    Log.e(TAG, "Avatar credentials are missing.")
+                    onAvatarCredentialsUnavailable()
+                    return
+                }
+
+                if (pendingAvatarMode) {
+                    // 認証情報の到着を待っていた切り替え要求を再開する
+                    pendingAvatarMode = false
+                    toggleAvatarMode(true)
+                } else if (getUIMode(this@MainActivity) != "") {
+                    toggleAvatarMode(getUIMode(this@MainActivity) == UIModeConfig.AVATAR.name)
                 }
             }
 
             override fun onCancelled(databaseError: DatabaseError) {
                 Log.e(TAG, "Database error: ${databaseError.message}")
+                onAvatarCredentialsUnavailable()
             }
         })
+    }
+
+    private fun onAvatarCredentialsUnavailable() {
+        if (!pendingAvatarMode) {
+            return
+        }
+        pendingAvatarMode = false
+        binding.progressBar.visibility = View.GONE
+        Toast.makeText(this, R.string.avatar_mode_error, Toast.LENGTH_SHORT).show()
     }
 
     private fun showAvatarModeInfoDialog() {
@@ -543,20 +564,19 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
                 request: WebResourceRequest?,
                 error: WebResourceError?
             ) {
-                if (request?.url?.host.equals("static.cloudflareinsights.com")) {
-                    // 計測用なので無視する
-                    Log.w(TAG, "Ignore loading error for insights")
+                if (request?.isForMainFrame != true) {
+                    // サブリソース（計測用スクリプトなど）の失敗は無視する
+                    Log.w(TAG, "Ignore loading error for sub resource: ${request?.url}")
                     return
                 }
                 Log.e(
                     TAG, "Avatar mode loading error: ${error?.errorCode}, ${error?.description}"
                 )
                 super.onReceivedError(view, request, error)
-                // Handle loading errors
+                // 一時的な失敗でモードを解除せず、再読み込みか戻るキーで復帰できるようにする
                 binding.progressBar.visibility = View.GONE
                 Toast.makeText(this@MainActivity, R.string.avatar_mode_error, Toast.LENGTH_SHORT)
                     .show()
-                toggleAvatarMode(false)
             }
         }
 
@@ -849,9 +869,12 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
     }
 
     private fun toggleAvatarMode(enable: Boolean = !isAvatarMode) {
-        if (::avatarClientId.isInitialized.not() || ::avatarClientSecret.isInitialized.not()) {
-            Log.e(TAG, "Avatar mode initialization error")
-            Toast.makeText(this, R.string.avatar_mode_error, Toast.LENGTH_SHORT).show()
+        if (enable && (avatarClientId.isEmpty() || avatarClientSecret.isEmpty())) {
+            // 認証情報がまだ届いていないので、待っていることを示して到着後に切り替える
+            Log.w(TAG, "Avatar credentials are not ready yet.")
+            pendingAvatarMode = true
+            binding.progressBar.visibility = View.VISIBLE
+            Toast.makeText(this, R.string.avatar_mode_preparing, Toast.LENGTH_SHORT).show()
             return
         }
 

--- a/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
@@ -109,6 +109,9 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
     private var pendingAvatarMode = false
     private var pendingAudioPermissionRequest: PermissionRequest? = null
 
+    // プロセス再生成前に開いていたアバターページ。次にアバターページを開くときに一度だけ使う
+    private var savedAvatarUrl: String? = null
+
     private var openAIPreviousResponse = ""
 
     private val job = SupervisorJob()
@@ -172,6 +175,13 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
         handleWindowInsets(view)
 
         detectIntent = DetectIntent(this, getDialogFlowSession())
+
+        // プロセス再生成からの復帰時は、アバターモードだった場合だけ開いていたページを引き継ぐ
+        savedAvatarUrl = if (savedInstanceState?.getBoolean(STATE_AVATAR_MODE) == true) {
+            savedInstanceState.getString(STATE_AVATAR_URL)
+        } else {
+            null
+        }
 
         initChatView()
         initDatabase()
@@ -607,11 +617,22 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
     }
 
     private fun loadAvatarPage() {
+        val restoredUrl = savedAvatarUrl
+        savedAvatarUrl = null
+        if (restoredUrl?.startsWith(BuildConfig.AVATAR_BASE_URL) == true) {
+            Log.d(TAG, "Restore the avatar page: $restoredUrl")
+            loadAvatarUrl(restoredUrl)
+            return
+        }
+        loadAvatarUrl(BuildConfig.AVATAR_BASE_URL)
+    }
+
+    private fun loadAvatarUrl(url: String) {
         val headers = mapOf(
             "CF-Access-Client-Id" to avatarClientId,
             "CF-Access-Client-Secret" to avatarClientSecret
         )
-        webView.loadUrl(BuildConfig.AVATAR_BASE_URL, headers)
+        webView.loadUrl(url, headers)
     }
 
     private fun showUserNameDialog(cancelable: Boolean = true) {
@@ -1043,6 +1064,18 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
         }
     }
 
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putBoolean(STATE_AVATAR_MODE, isAvatarMode)
+        if (!isAvatarMode || !::webView.isInitialized) {
+            return
+        }
+        // 復帰させられるのは開いていたページまで。ページ内のJS状態（アバターの姿勢や会話の途中）は戻らない。
+        // WebView.saveState() は使わない。モード切り替えで積まれた about:blank まで含む
+        // 前後の履歴が丸ごと戻り、戻るキーでチャットモードに帰れなくなるため。
+        outState.putString(STATE_AVATAR_URL, webView.url)
+    }
+
     public override fun onPause() {
         isActivityResumed = false
         if (::webView.isInitialized) {
@@ -1078,5 +1111,8 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
 
     companion object {
         val TAG = MainActivity::class.java.name.toString()
+
+        private const val STATE_AVATAR_MODE = "state_avatar_mode"
+        private const val STATE_AVATAR_URL = "state_avatar_url"
     }
 }

--- a/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
@@ -9,6 +9,7 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.Bundle
+import android.provider.Settings
 import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
@@ -136,11 +137,7 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
                 }
             } else {
                 request?.deny()
-                Toast.makeText(
-                    this,
-                    R.string.avatar_mode_needs_record_audio_permission,
-                    Toast.LENGTH_SHORT
-                ).show()
+                showRecordAudioPermissionDeniedDialog()
             }
         }
 
@@ -603,8 +600,7 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
                         if (checkSelfPermission(android.Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED) {
                             request.grant(arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE))
                         } else {
-                            pendingAudioPermissionRequest = request
-                            recordAudioPermissionLauncher.launch(android.Manifest.permission.RECORD_AUDIO)
+                            requestRecordAudioPermission(request)
                         }
                         return
                     }
@@ -614,6 +610,57 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
         }
 
         onBackPressedDispatcher.addCallback(this, avatarModeBackCallback)
+    }
+
+    private fun requestRecordAudioPermission(request: PermissionRequest? = null) {
+        pendingAudioPermissionRequest = request
+        // システムの権限ダイアログの前に、マイクを何のために使うのかを説明する
+        AlertDialog.Builder(this)
+            .setTitle(R.string.avatar_mode_record_audio_rationale_title)
+            .setMessage(R.string.avatar_mode_record_audio_rationale_message)
+            .setPositiveButton(R.string.avatar_mode_record_audio_continue) { _, _ ->
+                recordAudioPermissionLauncher.launch(android.Manifest.permission.RECORD_AUDIO)
+            }
+            .setNegativeButton(R.string.setting_dialog_cancel) { _, _ ->
+                denyPendingAudioPermissionRequest()
+            }
+            .setOnCancelListener { denyPendingAudioPermissionRequest() }
+            .show()
+    }
+
+    private fun denyPendingAudioPermissionRequest() {
+        pendingAudioPermissionRequest?.deny()
+        pendingAudioPermissionRequest = null
+    }
+
+    private fun showRecordAudioPermissionDeniedDialog() {
+        // 一度の拒否ならもう一度要求できる。二度拒否されると権限ダイアログが出ないので設定へ誘導する
+        val canRequestAgain =
+            shouldShowRequestPermissionRationale(android.Manifest.permission.RECORD_AUDIO)
+        val builder = AlertDialog.Builder(this)
+            .setTitle(R.string.avatar_mode_needs_record_audio_permission)
+            .setNegativeButton(R.string.setting_dialog_cancel, null)
+        if (canRequestAgain) {
+            builder.setMessage(R.string.avatar_mode_record_audio_denied_message)
+                .setPositiveButton(R.string.avatar_mode_record_audio_retry) { _, _ ->
+                    requestRecordAudioPermission()
+                }
+        } else {
+            builder.setMessage(R.string.avatar_mode_record_audio_blocked_message)
+                .setPositiveButton(R.string.avatar_mode_record_audio_open_settings) { _, _ ->
+                    openAppPermissionSettings()
+                }
+        }
+        builder.show()
+    }
+
+    private fun openAppPermissionSettings() {
+        try {
+            val uri = Uri.fromParts("package", packageName, null)
+            startActivity(Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, uri))
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to open the app settings: $e")
+        }
     }
 
     private fun loadAvatarPage() {

--- a/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
@@ -22,6 +22,7 @@ import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.Toast
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
@@ -137,6 +138,19 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
                 ).show()
             }
         }
+
+    private val avatarModeBackCallback = object : OnBackPressedCallback(false) {
+        override fun handleOnBackPressed() {
+            val backForwardList = webView.copyBackForwardList()
+            val previous = backForwardList.getItemAtIndex(backForwardList.currentIndex - 1)
+            if (webView.canGoBack() && previous?.url?.startsWith(BuildConfig.AVATAR_BASE_URL) == true) {
+                // アバターページ内の履歴を辿る
+                webView.goBack()
+            } else {
+                toggleAvatarMode(false)
+            }
+        }
+    }
 
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -563,6 +577,8 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
                 request.deny()
             }
         }
+
+        onBackPressedDispatcher.addCallback(this, avatarModeBackCallback)
     }
 
     private fun loadAvatarPage() {
@@ -841,6 +857,7 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
 
         isAvatarMode = enable
         setUIMode(this, if (isAvatarMode) UIModeConfig.AVATAR else UIModeConfig.CHAT)
+        avatarModeBackCallback.isEnabled = isAvatarMode
         invalidateOptionsMenu()
 
         if (isAvatarMode) {

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -58,6 +58,7 @@
     <string name="avatar_mode">アバターモード</string>
     <string name="avatar_mode_needs_record_audio_permission">音声入力の許可が必要です</string>
     <string name="avatar_mode_error">アバター画面の読み込みに失敗しました</string>
+    <string name="avatar_mode_preparing">アバターモードを準備しています…</string>
     <string name="avatar_mode_message_title">アバターモードが追加されました</string>
     <string name="avatar_mode_message_text">3Dアバターの初音ミクと会話できる機能が追加されました！（右上のアイコンをタップしてモードを切り替えることができます。）</string>
     <string name="avatar_mode_message_accept">使ってみる</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -57,6 +57,13 @@
     <string name="chat_mode">チャットモード</string>
     <string name="avatar_mode">アバターモード</string>
     <string name="avatar_mode_needs_record_audio_permission">音声入力の許可が必要です</string>
+    <string name="avatar_mode_record_audio_rationale_title">マイクを使用します</string>
+    <string name="avatar_mode_record_audio_rationale_message">アバターモードでは声で初音ミクに話しかけるため、マイクの使用許可が必要です。次の画面で許可してください。</string>
+    <string name="avatar_mode_record_audio_continue">続ける</string>
+    <string name="avatar_mode_record_audio_denied_message">マイクを許可しないと声で話しかけられません。もう一度許可するか、チャットモードで文字のまま会話できます。</string>
+    <string name="avatar_mode_record_audio_blocked_message">このアプリのマイクの使用が拒否されています。声で話しかけるには設定から許可してください。</string>
+    <string name="avatar_mode_record_audio_retry">もう一度許可する</string>
+    <string name="avatar_mode_record_audio_open_settings">設定を開く</string>
     <string name="avatar_mode_error">アバター画面の読み込みに失敗しました</string>
     <string name="avatar_mode_preparing">アバターモードを準備しています…</string>
     <string name="avatar_mode_message_title">アバターモードが追加されました</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,6 +59,7 @@
     <string name="avatar_mode">Avatar Mode</string>
     <string name="avatar_mode_needs_record_audio_permission">Please allow permission to talk by voice</string>
     <string name="avatar_mode_error">Failed to load avatar page</string>
+    <string name="avatar_mode_preparing">Preparing avatar mode…</string>
     <string name="avatar_mode_message_title">About Avatar Mode</string>
     <string name="avatar_mode_message_text">You can now talk to Hatsune Miku in 3D avatar mode! (You can change the mode from the button on the top right of the screen.)</string>
     <string name="avatar_mode_message_accept">Try Avatar Mode</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,6 +58,13 @@
     <string name="chat_mode">Chat Mode</string>
     <string name="avatar_mode">Avatar Mode</string>
     <string name="avatar_mode_needs_record_audio_permission">Please allow permission to talk by voice</string>
+    <string name="avatar_mode_record_audio_rationale_title">Use the microphone</string>
+    <string name="avatar_mode_record_audio_rationale_message">In avatar mode you talk to Hatsune Miku with your voice, so the app needs the microphone. Please allow it on the next screen.</string>
+    <string name="avatar_mode_record_audio_continue">Continue</string>
+    <string name="avatar_mode_record_audio_denied_message">You cannot talk by voice without the microphone. You can allow it again, or keep talking by text in chat mode.</string>
+    <string name="avatar_mode_record_audio_blocked_message">The microphone is blocked for this app. To talk by voice, allow it from Settings.</string>
+    <string name="avatar_mode_record_audio_retry">Allow again</string>
+    <string name="avatar_mode_record_audio_open_settings">Open Settings</string>
     <string name="avatar_mode_error">Failed to load avatar page</string>
     <string name="avatar_mode_preparing">Preparing avatar mode…</string>
     <string name="avatar_mode_message_title">About Avatar Mode</string>


### PR DESCRIPTION
Closes #92

アバターモードの WebView ライフサイクルと権限処理の不備を修正しました。

## 変更内容

### 1. マイク権限を ActivityResult API に移行（`MainActivity.kt`）

- 非推奨の `onRequestPermissionsResult` を削除し、`ActivityResultContracts.RequestPermission` に置き換え。
  権限ダイアログをキャンセルすると `grantResults` が空になり、`grantResults[0]` で
  `ArrayIndexOutOfBoundsException` になっていたクラッシュを解消。
- `WebChromeClient.onPermissionRequest` の `PermissionRequest` を保持し、許可されたらそのまま
  `grant()`（保持できていない場合のみ従来どおり `reload()`）、拒否されたら `deny()` + トースト表示。
- 使われていなかった `PERMISSIONS_REQUEST_RECORD_AUDIO` を削除。

### 2. WebView を Activity のライフサイクルに追従させる

- `onPause`: `webView.onPause()` / `pauseTimers()` でバックグラウンドの音声再生と 3D 描画を停止。
- `onResume`: `resumeTimers()` / `onResume()` で再開。
- `onDestroy`: `stopLoading()` → 親から `removeView()` → `destroy()`。

### 3. 戻るキーでチャットモードに戻る

- `OnBackPressedCallback` を登録（アバターモード時のみ有効）。
  アバターページ内の履歴があれば `goBack()`、履歴の先頭ならチャットモードへ戻す。
  `about:blank` に戻ってしまわないよう、遷移先が `AVATAR_BASE_URL` 配下かを確認しています。

### 4. 一時的な読み込み失敗でモードが強制解除されないようにする

- `onReceivedError` で `request.isForMainFrame` を判定し、サブリソースの失敗は無視
  （従来は `static.cloudflareinsights.com` のみ個別に除外していました）。
- メインドキュメントの失敗時もトースト表示のみに変更し、`toggleAvatarMode(false)` をやめました。
  復帰導線は既存のメニュー「再読み込み」と、今回追加した戻るキーです。

### 5. 認証情報の取得待ちを明示

- `avatarClientId` / `avatarClientSecret` を `lateinit` から空文字初期値の `var` に変更。
- 認証情報が未到着のままアバターモードに切り替えようとした場合は、プログレスバーと
  「アバターモードを準備しています…」のトーストを表示し、到着後に自動で切り替えます。
- 取得に失敗した場合（`onCancelled` / 値が空）はプログレスバーを消してエラーを表示します。
- 追加文字列: `avatar_mode_preparing`（ja / en）

なお、エラー画面への「再読み込み」ボタン設置などの UI 作り込みは #18、
メインスレッドブロッキングの解消は #98 のスコープとして本 PR には含めていません。

## 動作確認

`compileAdsDebugKotlin` / `compileNoAdsDebugKotlin` ともに成功（新規警告なし）。
エミュレータ（Pixel 9a AVD / Android 16, 1080x2424）に `installAdsDebug` して adb で検証しました。

| 受け入れ条件 | 結果 | 確認方法 |
| --- | --- | --- |
| マイク権限ダイアログをキャンセルしてもクラッシュしない | OK | `pm revoke RECORD_AUDIO` 後にアバターページのマイクボタンをタップ → 権限ダイアログを戻るキーでキャンセル／「Don't allow」でも実施。logcat に `FATAL EXCEPTION` / `ArrayIndexOutOfBoundsException` なし、プロセス継続、アバターモード維持 |
| アバターモードで戻るキーを押すとチャットモードに戻る | OK | アバターモードで `KEYCODE_BACK` → uiautomator dump に `chat_view` / `chatContainer` が出現。チャットモードでもう一度押すとアプリ終了（コールバックが無効化されている） |
| バックグラウンド遷移で WebView の音声/描画が停止する | OK | `KEYCODE_HOME` 前後の WebView レンダラプロセス（`sandboxed_process0`）の CPU: 19.2% → 0.0%。累積 CPU 時間も 12 秒間で 0:20.06 → 0:20.08 とほぼ停止。復帰後は 19.2% に戻る（検証中は `onPause`/`onResume` に一時的な Log.d を入れて経路も確認し、コミット前に削除済み） |
| 一時的な読み込み失敗でモードが強制解除されない | OK | アバターページ表示中に `svc wifi disable` / `svc data disable` → メニューの「再読み込み」を実行。`net::ERR_INTERNET_DISCONNECTED` でエラートーストは出るがアバターモードのまま（UI ツリーにチャット画面なし、`UI_MODE` の pref も `AVATAR` を維持）。インサイト用サブリソースの失敗は "Ignore loading error for sub resource" としてスキップ。通信を戻して再読み込みすると復帰。検証後にネットワークは復旧済み |

そのほか、アプリ終了（`onDestroy` で `webView.destroy()`）→ 同一プロセスで再起動 → アバターモード再表示までを通し、
例外が出ないことと再表示できることも確認しています。


---

## 追記: issue #92 の問題点 4 と 8 にも対応

受け入れ条件には入っていませんが、issue に挙がっていた残り 2 点も対応しました。

### 6. プロセス再生成時にアバターページへ戻る（問題点 4）

- `onSaveInstanceState` でアバターモードかどうかと、WebView が開いていた URL を保存し、
  次にアバターページを開くときにその URL を（Cloudflare Access のヘッダー付きで）読み直します。
- **`WebView.saveState()` は意図的に使っていません。** 実機で確認したところ、
  `saveState()` は前後の履歴を丸ごと保存するため、モード切り替えで積まれた `about:blank` や
  過去のアバターページまで復元されてしまいます。
  実測した復元後の履歴: `size=5 current=4 [0]about:blank, [1]…/, [2]about:blank, [3]…/, [4]…/`。
  この状態では戻るキーが古い履歴を辿るだけになり、
  「戻るキーでチャットモードに戻る」という既存の受け入れ条件が壊れました（2 回押さないと戻れない）。
  そのため履歴ではなく「開いていたページ」だけを復元する形にしています。
- **復元できるのは開いていたページまでです。** ページ内の JS 状態
  （3D アバターの姿勢、会話の途中）は `saveState()` を使ったとしても保存されないため、
  復帰時は初期状態から始まります。過剰な期待を持たせないようコード中にもコメントを残しました。
- なお `configChanges="orientation|screenSize"` があるため、画面回転では Activity が
  再生成されず、この経路は通りません（回転では元々状態が保たれます）。

### 7. マイク権限の事前説明と再要求導線（問題点 8）

- 権限を要求する前に「アバターモードでは声で話しかけるためにマイクを使う」ことを説明する
  ダイアログを表示し、「続ける」でシステムの権限ダイアログへ進みます。
  ここでキャンセルした場合は WebView の `PermissionRequest` を `deny()` します（従来と同じ）。
- 拒否された場合は `shouldShowRequestPermissionRationale` で状態を見て導線を分けます。
  - まだ要求できる場合: 「もう一度許可する」→ 説明ダイアログから再要求。
  - 「今後表示しない」相当まで拒否された場合: 「設定を開く」→ アプリ情報画面
    （`ACTION_APPLICATION_DETAILS_SETTINGS`）へ遷移。
- 従来の拒否時トーストはこのダイアログに置き換えました
  （`avatar_mode_needs_record_audio_permission` はダイアログのタイトルとして流用）。
- 追加文字列（ja / en 両方）: `avatar_mode_record_audio_rationale_title` /
  `_rationale_message` / `_continue` / `_denied_message` / `_blocked_message` /
  `_retry` / `_open_settings`

## 追記分の動作確認

`compileAdsDebugKotlin` / `compileNoAdsDebugKotlin` / `lintAdsDebug` / `testAdsDebugUnitTest`
いずれも成功。エミュレータ（Android 16, 1080x2424）に `installAdsDebug` して adb で検証しました。

| 項目 | 結果 | 確認方法 |
| --- | --- | --- |
| プロセス再生成からの復帰 | OK | アバターモードで HOME → `am kill`（プロセス消滅を `pidof` で確認）→ ランチャーから再開。新しい pid で `Restore the avatar page: https://youbimiku.aqua-ix.com/` がログに出て、アバターモードとページが復元されることをスクリーンショットで確認 |
| 復帰後も戻るキー 1 回でチャットモードに戻る | OK | 復帰直後に `KEYCODE_BACK` 1 回でチャット画面（`Message…` の入力欄）に戻る。`saveState()` を使っていた実装では 2 回必要だったため、この方式に変更しています |
| 画面回転で Activity が再生成されない | OK | `settings put system user_rotation 1` で横向きにしても `onCreate` のログ（`getDialogFlowSession()`）が増えず、アバターも表示が崩れない。検証後に向き・自動回転設定は元に戻し済み |
| 権限の事前説明が出る | OK | `pm revoke RECORD_AUDIO` 後にマイクボタンをタップ → 「Use the microphone」の説明ダイアログ → 「CONTINUE」でシステムダイアログが表示される |
| 拒否後の再要求導線 | OK | 1 回目の拒否後は「Please allow permission to talk by voice / ALLOW AGAIN」が表示され、再要求すると説明ダイアログからやり直せる。さらに拒否すると「…allow it from Settings / OPEN SETTINGS」に変わり、アプリ情報画面が開くことを確認 |
| 説明ダイアログのキャンセル | OK | 「CANCEL」でダイアログを閉じても `FATAL EXCEPTION` なし、アバターモードのまま |
| 許可した場合 | OK | 「While using the app」で許可すると `PermissionRequest.grant()` が通り、ページの音声認識が開始される（マイクボタンが録音状態に変わる） |

既存の受け入れ条件 4 項目も、この差分を含んだビルドで再確認しました。

| 受け入れ条件 | 結果 | 確認方法 |
| --- | --- | --- |
| マイク権限ダイアログをキャンセルしてもクラッシュしない | OK | 説明ダイアログのキャンセル / 「Don't allow」いずれも `FATAL EXCEPTION` なし |
| アバターモードで戻るキーを押すとチャットモードに戻る | OK | 通常起動時・プロセス復帰時ともに 1 回で戻る |
| バックグラウンド遷移で WebView の音声/描画が停止する | OK | WebView レンダラプロセスの CPU が 11.5% → 0.0% |
| 一時的な読み込み失敗でモードが強制解除されない | OK | `svc wifi/data disable` 後に再読み込み → `net::ERR_INTERNET_DISCONNECTED` でもアバターモードのまま。通信を戻して再読み込みすると復帰。ネットワークは復旧済み |

検証用に入れた一時ログはコミット前に削除済みです。
