### PR TITLE
noAdsフレーバーに広告SDKを同梱しないようにする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ YoubiMiku (ユビキタ初音ミク) is an Android chat application where users 
 
 - **Kotlin 1.9.23**, **AGP 8.7.2**, **JDK 17** (Temurin in CI), Java target 1.8
 - **Compile/Target SDK 35**, Min SDK 23
-- **Two product flavors**: `ads` (with ad SDKs) and `noAds` (ad-free)
+- **Two product flavors**: `ads` (with ad SDKs) and `noAds` (ad-free), each with its own source set (`app/src/ads/`, `app/src/noAds/`) and manifest
 - Namespace: `com.aqua_ix.youbimiku`
 - ViewBinding enabled, Room schema exported via KSP
 
@@ -41,6 +41,7 @@ Single-module Android app with an activity-centric architecture. Nearly all UI l
 - **AI Integration**: `DetectIntent.kt` (DialogFlow v2), OpenAI via `com.aallam.openai` library
 - **Config**: `config/` package — type-safe enums for AI model, font size, language, UI mode; `SharedPreferenceManager` wraps SharedPreferences; Firebase RemoteConfig controls feature flags
 - **Data**: Room database (`database/` package) stores chat messages; Firebase Realtime DB stores API keys and credentials at runtime
+- **Ads**: `ads/` package — `AdController` interface in `main`, implementations per flavor
 - **Utilities**: `TranslateUtil` (EN↔JP translation via HTTP), `ReportUtil` (message reporting)
 
 ### Configuration System
@@ -53,7 +54,9 @@ Room ORM with a single `MessageEntity` table. Two schema versions with auto-migr
 
 ### Ad Integration
 
-Two ad networks (iMobile, IronSource) switchable via RemoteConfig. The `ads` flavor includes ad SDKs; `noAds` flavor excludes them. Interstitial ads trigger after a configurable message count.
+Two ad networks (iMobile, IronSource) switchable via RemoteConfig. Interstitial ads trigger after a configurable message count.
+
+Ad SDKs are declared with the `adsImplementation` configuration, so only the `ads` flavor bundles them. `MainActivity` never references ad SDK classes directly: it goes through the `AdController` interface (`ads/AdController.kt` in the `main` source set) and obtains an instance from `AdControllerFactory`, which is defined per flavor — `AdNetworkController` (iMobile/IronSource) in `app/src/ads/`, `NoOpAdController` in `app/src/noAds/`. The `noAds` manifest also removes the `AD_ID` permission that dependencies merge in.
 
 ## Deploy to Device (WSL)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ YoubiMiku (ユビキタ初音ミク) is an Android chat application where users 
 ## Build Configuration
 
 - **Kotlin 1.9.23**, **AGP 8.7.2**, **JDK 17** (Temurin in CI), Java target 1.8
-- **Compile/Target SDK 35**, Min SDK 23
+- **Compile/Target SDK 36**, Min SDK 23
 - **Two product flavors**: `ads` (with ad SDKs) and `noAds` (ad-free), each with its own source set (`app/src/ads/`, `app/src/noAds/`) and manifest
 - Namespace: `com.aqua_ix.youbimiku`
 - ViewBinding enabled, Room schema exported via KSP

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,7 +78,6 @@ dependencies {
     implementation("androidx.room:room-ktx:$roomVersion")
 
     implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.23")
-    implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
     implementation("com.google.firebase:firebase-database-ktx:21.0.0")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.1.0") {
         exclude(group = "com.android.support", module = "support-annotations")
@@ -109,11 +108,13 @@ dependencies {
     implementation(platform("com.google.firebase:firebase-bom:33.5.1"))
     implementation("com.google.firebase:firebase-config-ktx")
     implementation("com.google.firebase:firebase-analytics-ktx")
-    implementation("com.google.android.gms:play-services-appset:16.1.0")
-    implementation("com.google.android.gms:play-services-ads-identifier:18.1.0")
     implementation("com.google.android.gms:play-services-basement:18.4.0")
-    implementation(files("libs/imobileSdkAds.jar"))
-    implementation("com.ironsource.sdk:mediationsdk:8.12.0")
+
+    // 広告SDKは ads フレーバーにのみ同梱する
+    "adsImplementation"(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
+    "adsImplementation"("com.ironsource.sdk:mediationsdk:8.12.0")
+    "adsImplementation"("com.google.android.gms:play-services-appset:16.1.0")
+    "adsImplementation"("com.google.android.gms:play-services-ads-identifier:18.1.0")
 }
 
 secrets {

--- a/app/src/ads/AndroidManifest.xml
+++ b/app/src/ads/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
+
+    <application>
+
+        <meta-data
+            android:name="i-mobile_Testing"
+            android:value="${imobile_Testing}" />
+        <meta-data
+            android:name="i-mobile_DebugLogging"
+            android:value="${imobile_Testing}" />
+    </application>
+
+</manifest>

--- a/app/src/ads/java/com/aqua_ix/youbimiku/ads/AdControllerFactory.kt
+++ b/app/src/ads/java/com/aqua_ix/youbimiku/ads/AdControllerFactory.kt
@@ -1,0 +1,8 @@
+package com.aqua_ix.youbimiku.ads
+
+/**
+ * `ads` フレーバー用のファクトリ。広告SDKを呼び出す実装を返す。
+ */
+object AdControllerFactory {
+    fun create(): AdController = AdNetworkController()
+}

--- a/app/src/ads/java/com/aqua_ix/youbimiku/ads/AdNetworkController.kt
+++ b/app/src/ads/java/com/aqua_ix/youbimiku/ads/AdNetworkController.kt
@@ -1,0 +1,280 @@
+package com.aqua_ix.youbimiku.ads
+
+import android.util.Log
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
+import android.widget.FrameLayout
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
+import com.aqua_ix.youbimiku.BuildConfig.BUILD_TYPE
+import com.aqua_ix.youbimiku.BuildConfig.IMOBILE_BANNER_SID
+import com.aqua_ix.youbimiku.BuildConfig.IMOBILE_INTERSTITIAL_SID
+import com.aqua_ix.youbimiku.BuildConfig.IMOBILE_MID
+import com.aqua_ix.youbimiku.BuildConfig.IMOBILE_PID
+import com.aqua_ix.youbimiku.BuildConfig.IRONSOURCE_APP_KEY
+import com.aqua_ix.youbimiku.RemoteConfigKey
+import com.ironsource.mediationsdk.ISBannerSize
+import com.ironsource.mediationsdk.IronSource
+import com.ironsource.mediationsdk.IronSourceBannerLayout
+import com.ironsource.mediationsdk.adunit.adapter.utility.AdInfo
+import com.ironsource.mediationsdk.integration.IntegrationHelper
+import com.ironsource.mediationsdk.logger.IronSourceError
+import com.ironsource.mediationsdk.sdk.LevelPlayBannerListener
+import com.ironsource.mediationsdk.sdk.LevelPlayInterstitialListener
+import jp.co.imobile.sdkads.android.FailNotificationReason
+import jp.co.imobile.sdkads.android.ImobileSdkAd
+import jp.co.imobile.sdkads.android.ImobileSdkAdListener
+
+/**
+ * `ads` フレーバー向けの実装。iMobileとIronSourceのSDKを直接呼び出す。
+ * 初期化した広告ネットワークを保持し、ライフサイクル処理は初期化済みのものだけを対象にする。
+ */
+class AdNetworkController : AdController {
+    private var adNetwork = ""
+    private var ironSourceBannerLayout: IronSourceBannerLayout? = null
+
+    override fun setup(
+        activity: AppCompatActivity,
+        adNetwork: String,
+        actionBarSize: Int,
+        onBannerHeightChanged: (Int) -> Unit
+    ) {
+        when (adNetwork) {
+            RemoteConfigKey.AdNetwork.IMOBILE -> {
+                initImobileBanner(activity, actionBarSize, onBannerHeightChanged)
+                initImobileInterstitial(activity)
+            }
+
+            RemoteConfigKey.AdNetwork.IRONSOURCE -> {
+                initIronSource(activity, actionBarSize, onBannerHeightChanged)
+            }
+
+            else -> {
+                Log.d(TAG, "Ad network is not configured: $adNetwork")
+                return
+            }
+        }
+        this.adNetwork = adNetwork
+    }
+
+    private fun initImobileBanner(
+        activity: AppCompatActivity,
+        actionBarSize: Int,
+        onBannerHeightChanged: (Int) -> Unit
+    ) {
+        ImobileSdkAd.registerSpotInline(
+            activity,
+            IMOBILE_PID,
+            IMOBILE_MID,
+            IMOBILE_BANNER_SID
+        )
+        ImobileSdkAd.start(IMOBILE_BANNER_SID)
+
+        val imobileBannerLayout = FrameLayout(activity)
+        val imobileBannerLayoutParam = FrameLayout.LayoutParams(WRAP_CONTENT, WRAP_CONTENT)
+        imobileBannerLayoutParam.gravity = Gravity.TOP or Gravity.CENTER
+        imobileBannerLayout.visibility = View.INVISIBLE
+        activity.addContentView(imobileBannerLayout, imobileBannerLayoutParam)
+        ViewCompat.setOnApplyWindowInsetsListener(imobileBannerLayout) { v, windowInsets ->
+            val insets = windowInsets.getInsets(
+                WindowInsetsCompat.Type.systemBars()
+                        or WindowInsetsCompat.Type.displayCutout()
+            )
+            v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                topMargin = insets.top + actionBarSize
+            }
+            windowInsets
+        }
+        ImobileSdkAd.showAd(activity, IMOBILE_BANNER_SID, imobileBannerLayout, true)
+
+        ImobileSdkAd.setImobileSdkAdListener(IMOBILE_BANNER_SID, object : ImobileSdkAdListener() {
+            override fun onAdShowCompleted() {
+                Log.d(TAG, "ImobileSdkAd($IMOBILE_BANNER_SID) onAdReadyCompleted")
+                imobileBannerLayout.visibility = View.VISIBLE
+                onBannerHeightChanged(imobileBannerLayout.height)
+            }
+
+            override fun onFailed(reason: FailNotificationReason) {
+                Log.d(TAG, "ImobileSdkAd($IMOBILE_BANNER_SID) onFailed: $reason")
+                imobileBannerLayout.visibility = View.INVISIBLE
+                onBannerHeightChanged(0)
+            }
+        })
+    }
+
+    private fun initImobileInterstitial(activity: AppCompatActivity) {
+        ImobileSdkAd.registerSpotFullScreen(
+            activity,
+            IMOBILE_PID,
+            IMOBILE_MID,
+            IMOBILE_INTERSTITIAL_SID
+        )
+        ImobileSdkAd.start(IMOBILE_INTERSTITIAL_SID)
+    }
+
+    private fun initIronSource(
+        activity: AppCompatActivity,
+        actionBarSize: Int,
+        onBannerHeightChanged: (Int) -> Unit
+    ) {
+        val bannerLayout = initIronSourceBanner(activity, actionBarSize, onBannerHeightChanged)
+        initIronSourceInterstitial()
+        IronSource.init(
+            activity,
+            IRONSOURCE_APP_KEY,
+            IronSource.AD_UNIT.BANNER,
+            IronSource.AD_UNIT.INTERSTITIAL
+        )
+        IronSource.loadBanner(bannerLayout)
+        IronSource.loadInterstitial()
+    }
+
+    private fun initIronSourceBanner(
+        activity: AppCompatActivity,
+        actionBarSize: Int,
+        onBannerHeightChanged: (Int) -> Unit
+    ): IronSourceBannerLayout {
+        val size = ISBannerSize.BANNER
+        val bannerLayout = IronSource.createBanner(activity, size)
+        ironSourceBannerLayout = bannerLayout
+        bannerLayout.apply {
+            levelPlayBannerListener = object : LevelPlayBannerListener {
+                override fun onAdLoaded(adInfo: AdInfo) {
+                    Log.d(TAG, "IronSource banner loaded: $adInfo")
+                    onBannerHeightChanged(bannerLayout.height)
+                }
+
+                override fun onAdLoadFailed(error: IronSourceError) {
+                    Log.e(TAG, "IronSource banner load failed: $error")
+                    onBannerHeightChanged(0)
+                }
+
+                override fun onAdClicked(adInfo: AdInfo) {
+                    Log.d(TAG, "IronSource banner clicked: $adInfo")
+                }
+
+                override fun onAdScreenPresented(adInfo: AdInfo) {
+                    Log.d(TAG, "IronSource banner screen presented: $adInfo")
+                }
+
+                override fun onAdScreenDismissed(adInfo: AdInfo) {
+                    Log.d(TAG, "IronSource banner screen dismissed: $adInfo")
+                }
+
+                override fun onAdLeftApplication(adInfo: AdInfo) {
+                    Log.d(TAG, "IronSource banner left application: $adInfo")
+                }
+            }
+
+            val layoutParams = FrameLayout.LayoutParams(WRAP_CONTENT, WRAP_CONTENT).apply {
+                gravity = Gravity.TOP or Gravity.CENTER
+            }
+            activity.addContentView(bannerLayout, layoutParams)
+            ViewCompat.setOnApplyWindowInsetsListener(bannerLayout) { v, windowInsets ->
+                val insets = windowInsets.getInsets(
+                    WindowInsetsCompat.Type.systemBars()
+                            or WindowInsetsCompat.Type.displayCutout()
+                )
+                v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                    topMargin = insets.top + actionBarSize
+                }
+                windowInsets
+            }
+            if (BUILD_TYPE == "debug") {
+                IntegrationHelper.validateIntegration(activity)
+            }
+        }
+        return bannerLayout
+    }
+
+    private fun initIronSourceInterstitial() {
+        IronSource.setLevelPlayInterstitialListener(object : LevelPlayInterstitialListener {
+            override fun onAdReady(adInfo: AdInfo) {
+                Log.d(TAG, "IronSource interstitial ready: $adInfo")
+            }
+
+            override fun onAdLoadFailed(error: IronSourceError?) {
+                Log.e(TAG, "IronSource interstitial load failed: $error")
+            }
+
+            override fun onAdOpened(adInfo: AdInfo) {
+                Log.d(TAG, "IronSource interstitial opened: $adInfo")
+            }
+
+            override fun onAdShowSucceeded(adInfo: AdInfo) {
+                Log.d(TAG, "IronSource interstitial show succeeded: $adInfo")
+            }
+
+            override fun onAdShowFailed(error: IronSourceError?, adInfo: AdInfo) {
+                Log.e(TAG, "IronSource interstitial show failed: $error, $adInfo")
+            }
+
+            override fun onAdClicked(adInfo: AdInfo) {
+                Log.d(TAG, "IronSource interstitial clicked: $adInfo")
+            }
+
+            override fun onAdClosed(adInfo: AdInfo) {
+                Log.d(TAG, "IronSource interstitial closed: $adInfo")
+            }
+        })
+    }
+
+    override fun showInterstitial(activity: AppCompatActivity) {
+        when (adNetwork) {
+            RemoteConfigKey.AdNetwork.IMOBILE -> {
+                Log.d(TAG, "ImobileSdkAd.showAd")
+                ImobileSdkAd.showAd(activity, IMOBILE_INTERSTITIAL_SID)
+            }
+
+            RemoteConfigKey.AdNetwork.IRONSOURCE -> {
+                Log.d(TAG, "IronSource.showInterstitial")
+                IronSource.showInterstitial()
+            }
+        }
+    }
+
+    override fun onResume(activity: AppCompatActivity) {
+        when (adNetwork) {
+            RemoteConfigKey.AdNetwork.IMOBILE -> {
+                ImobileSdkAd.start(IMOBILE_BANNER_SID)
+            }
+
+            RemoteConfigKey.AdNetwork.IRONSOURCE -> {
+                IronSource.onResume(activity)
+            }
+        }
+    }
+
+    override fun onPause(activity: AppCompatActivity) {
+        when (adNetwork) {
+            RemoteConfigKey.AdNetwork.IMOBILE -> {
+                ImobileSdkAd.stop(IMOBILE_BANNER_SID)
+            }
+
+            RemoteConfigKey.AdNetwork.IRONSOURCE -> {
+                IronSource.onPause(activity)
+            }
+        }
+    }
+
+    override fun onDestroy(activity: AppCompatActivity) {
+        when (adNetwork) {
+            RemoteConfigKey.AdNetwork.IMOBILE -> {
+                ImobileSdkAd.stop(IMOBILE_BANNER_SID)
+                ImobileSdkAd.stop(IMOBILE_INTERSTITIAL_SID)
+            }
+
+            RemoteConfigKey.AdNetwork.IRONSOURCE -> {
+                ironSourceBannerLayout?.let { IronSource.destroyBanner(it) }
+            }
+        }
+    }
+
+    companion object {
+        val TAG = AdNetworkController::class.java.name.toString()
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="com.google.android.gms.permission.AD_ID "/>
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
 
@@ -19,12 +18,6 @@
         <meta-data
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />
-        <meta-data
-            android:name="i-mobile_Testing"
-            android:value="${imobile_Testing}" />
-        <meta-data
-            android:name="i-mobile_DebugLogging"
-            android:value="${imobile_Testing}" />
 
         <activity
             android:name=".MainActivity"

--- a/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
@@ -10,12 +10,10 @@ import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.Bundle
 import android.util.Log
-import android.view.Gravity
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.webkit.PermissionRequest
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceError
@@ -23,14 +21,12 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import android.widget.FrameLayout
 import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
 import androidx.room.Room
 import com.aallam.openai.api.chat.ChatCompletionRequest
@@ -40,13 +36,8 @@ import com.aallam.openai.api.core.FinishReason
 import com.aallam.openai.api.model.ModelId
 import com.aallam.openai.client.OpenAI
 import com.aallam.openai.client.OpenAIConfig
-import com.aqua_ix.youbimiku.BuildConfig.BUILD_TYPE
-import com.aqua_ix.youbimiku.BuildConfig.FLAVOR
-import com.aqua_ix.youbimiku.BuildConfig.IMOBILE_BANNER_SID
-import com.aqua_ix.youbimiku.BuildConfig.IMOBILE_INTERSTITIAL_SID
-import com.aqua_ix.youbimiku.BuildConfig.IMOBILE_MID
-import com.aqua_ix.youbimiku.BuildConfig.IMOBILE_PID
-import com.aqua_ix.youbimiku.BuildConfig.IRONSOURCE_APP_KEY
+import com.aqua_ix.youbimiku.ads.AdController
+import com.aqua_ix.youbimiku.ads.AdControllerFactory
 import com.aqua_ix.youbimiku.config.AIModelConfig
 import com.aqua_ix.youbimiku.config.FontSizeConfig
 import com.aqua_ix.youbimiku.config.Key
@@ -81,17 +72,6 @@ import com.google.firebase.ktx.Firebase
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.ktx.remoteConfig
 import com.google.firebase.remoteconfig.ktx.remoteConfigSettings
-import com.ironsource.mediationsdk.ISBannerSize
-import com.ironsource.mediationsdk.IronSource
-import com.ironsource.mediationsdk.IronSourceBannerLayout
-import com.ironsource.mediationsdk.adunit.adapter.utility.AdInfo
-import com.ironsource.mediationsdk.integration.IntegrationHelper
-import com.ironsource.mediationsdk.logger.IronSourceError
-import com.ironsource.mediationsdk.sdk.LevelPlayBannerListener
-import com.ironsource.mediationsdk.sdk.LevelPlayInterstitialListener
-import jp.co.imobile.sdkads.android.FailNotificationReason
-import jp.co.imobile.sdkads.android.ImobileSdkAd
-import jp.co.imobile.sdkads.android.ImobileSdkAdListener
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -116,7 +96,7 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
     private lateinit var firebaseDatabase: FirebaseDatabase
     private lateinit var appDatabase: AppDatabase
     private lateinit var navMenu: Menu
-    private lateinit var ironSourceBannerLayout: IronSourceBannerLayout
+    private val adController: AdController = AdControllerFactory.create()
 
     private var isAvatarMode = false
     private lateinit var webView: WebView
@@ -289,176 +269,15 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
     }
 
     private fun setupAdNetwork() {
-        if (FLAVOR == "noAds") {
-            Log.d(TAG, "Ad network is disabled by flavor.")
-            return
-        }
-        when (remoteConfig.getString(RemoteConfigKey.AD_NETWORK)) {
-            RemoteConfigKey.AdNetwork.IMOBILE -> {
-                initImobileBanner()
-                initImobileInterstitial()
-            }
-
-            RemoteConfigKey.AdNetwork.IRONSOURCE -> {
-                initIronSource()
-            }
-        }
-    }
-
-    private fun initImobileBanner() {
-        ImobileSdkAd.registerSpotInline(
+        adController.setup(
             this,
-            IMOBILE_PID,
-            IMOBILE_MID,
-            IMOBILE_BANNER_SID
-        )
-        ImobileSdkAd.start(IMOBILE_BANNER_SID)
-
-        val imobileBannerLayout = FrameLayout(this)
-        val imobileBannerLayoutParam = FrameLayout.LayoutParams(WRAP_CONTENT, WRAP_CONTENT)
-        imobileBannerLayoutParam.gravity = Gravity.TOP or Gravity.CENTER
-        imobileBannerLayout.visibility = View.INVISIBLE
-        addContentView(imobileBannerLayout, imobileBannerLayoutParam)
-        ViewCompat.setOnApplyWindowInsetsListener(imobileBannerLayout) { v, windowInsets ->
-            val insets = windowInsets.getInsets(
-                WindowInsetsCompat.Type.systemBars()
-                        or WindowInsetsCompat.Type.displayCutout()
-            )
-            v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-                topMargin = insets.top + actionBarSize
-            }
-            windowInsets
+            remoteConfig.getString(RemoteConfigKey.AD_NETWORK),
+            actionBarSize
+        ) { height ->
+            val mlp = binding.chatView.layoutParams as ViewGroup.MarginLayoutParams
+            mlp.topMargin = height
+            binding.chatView.requestLayout()
         }
-        ImobileSdkAd.showAd(this, IMOBILE_BANNER_SID, imobileBannerLayout, true)
-
-        val mlp = binding.chatView.layoutParams as ViewGroup.MarginLayoutParams
-
-        ImobileSdkAd.setImobileSdkAdListener(IMOBILE_BANNER_SID, object : ImobileSdkAdListener() {
-            override fun onAdShowCompleted() {
-                Log.d(TAG, "ImobileSdkAd($IMOBILE_BANNER_SID) onAdReadyCompleted")
-                imobileBannerLayout.visibility = View.VISIBLE
-                mlp.topMargin = imobileBannerLayout.height
-                binding.chatView.requestLayout()
-            }
-
-            override fun onFailed(reason: FailNotificationReason) {
-                Log.d(TAG, "ImobileSdkAd($IMOBILE_BANNER_SID) onFailed: $reason")
-                imobileBannerLayout.visibility = View.INVISIBLE
-                mlp.topMargin = 0
-                binding.chatView.requestLayout()
-            }
-        })
-    }
-
-    private fun initImobileInterstitial() {
-        ImobileSdkAd.registerSpotFullScreen(
-            this,
-            IMOBILE_PID,
-            IMOBILE_MID,
-            IMOBILE_INTERSTITIAL_SID
-        )
-        ImobileSdkAd.start(IMOBILE_INTERSTITIAL_SID)
-    }
-
-    private fun initIronSource() {
-        initIronSourceBanner()
-        initIronSourceInterstitial()
-        IronSource.init(
-            this,
-            IRONSOURCE_APP_KEY,
-            IronSource.AD_UNIT.BANNER,
-            IronSource.AD_UNIT.INTERSTITIAL
-        )
-        IronSource.loadBanner(ironSourceBannerLayout)
-        IronSource.loadInterstitial()
-    }
-
-    private fun initIronSourceBanner() {
-        val size = ISBannerSize.BANNER
-        ironSourceBannerLayout = IronSource.createBanner(this, size)
-        ironSourceBannerLayout.apply {
-            ironSourceBannerLayout.levelPlayBannerListener = object : LevelPlayBannerListener {
-                override fun onAdLoaded(adInfo: AdInfo) {
-                    Log.d(TAG, "IronSource banner loaded: $adInfo")
-                    val mlp = binding.chatView.layoutParams as ViewGroup.MarginLayoutParams
-                    mlp.topMargin = ironSourceBannerLayout.height
-                    binding.chatView.requestLayout()
-                }
-
-                override fun onAdLoadFailed(error: IronSourceError) {
-                    Log.e(TAG, "IronSource banner load failed: $error")
-                    val mlp = binding.chatView.layoutParams as ViewGroup.MarginLayoutParams
-                    mlp.topMargin = 0
-                    binding.chatView.requestLayout()
-                }
-
-                override fun onAdClicked(adInfo: AdInfo) {
-                    Log.d(TAG, "IronSource banner clicked: $adInfo")
-                }
-
-                override fun onAdScreenPresented(adInfo: AdInfo) {
-                    Log.d(TAG, "IronSource banner screen presented: $adInfo")
-                }
-
-                override fun onAdScreenDismissed(adInfo: AdInfo) {
-                    Log.d(TAG, "IronSource banner screen dismissed: $adInfo")
-                }
-
-                override fun onAdLeftApplication(adInfo: AdInfo) {
-                    Log.d(TAG, "IronSource banner left application: $adInfo")
-                }
-            }
-
-            val layoutParams = FrameLayout.LayoutParams(WRAP_CONTENT, WRAP_CONTENT).apply {
-                gravity = Gravity.TOP or Gravity.CENTER
-            }
-            addContentView(ironSourceBannerLayout, layoutParams)
-            ViewCompat.setOnApplyWindowInsetsListener(ironSourceBannerLayout) { v, windowInsets ->
-                val insets = windowInsets.getInsets(
-                    WindowInsetsCompat.Type.systemBars()
-                            or WindowInsetsCompat.Type.displayCutout()
-                )
-                v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-                    topMargin = insets.top + actionBarSize
-                }
-                windowInsets
-            }
-            if (BUILD_TYPE == "debug") {
-                IntegrationHelper.validateIntegration(context);
-            }
-        }
-    }
-
-    private fun initIronSourceInterstitial() {
-        IronSource.setLevelPlayInterstitialListener(object : LevelPlayInterstitialListener {
-            override fun onAdReady(adInfo: AdInfo) {
-                Log.d(TAG, "IronSource interstitial ready: $adInfo")
-            }
-
-            override fun onAdLoadFailed(error: IronSourceError?) {
-                Log.e(TAG, "IronSource interstitial load failed: $error")
-            }
-
-            override fun onAdOpened(adInfo: AdInfo) {
-                Log.d(TAG, "IronSource interstitial opened: $adInfo")
-            }
-
-            override fun onAdShowSucceeded(adInfo: AdInfo) {
-                Log.d(TAG, "IronSource interstitial show succeeded: $adInfo")
-            }
-
-            override fun onAdShowFailed(error: IronSourceError?, adInfo: AdInfo) {
-                Log.e(TAG, "IronSource interstitial show failed: $error, $adInfo")
-            }
-
-            override fun onAdClicked(adInfo: AdInfo) {
-                Log.d(TAG, "IronSource interstitial clicked: $adInfo")
-            }
-
-            override fun onAdClosed(adInfo: AdInfo) {
-                Log.d(TAG, "IronSource interstitial closed: $adInfo")
-            }
-        })
     }
 
     private fun getMikuAccountFromAIModel(): User {
@@ -1052,18 +871,7 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
         if (count >= remoteConfig.getDouble(RemoteConfigKey.AD_DISPLAY_REQUEST_TIMES)) {
             Log.d(TAG, "Ad display request count: $count")
             setOpenAIRequestCount(applicationContext, 0)
-            when (remoteConfig.getString(RemoteConfigKey.AD_NETWORK)) {
-                RemoteConfigKey.AdNetwork.IMOBILE -> {
-                    Log.d(TAG, "ImobileSdkAd.showAd")
-                    ImobileSdkAd.showAd(this, IMOBILE_INTERSTITIAL_SID)
-                }
-
-                RemoteConfigKey.AdNetwork.IRONSOURCE -> {
-                    Log.d(TAG, "IronSource.showInterstitial")
-                    IronSource.showInterstitial()
-                    setOpenAIRequestCount(applicationContext, 0)
-                }
-            }
+            adController.showInterstitial(this)
         }
 
         val supportTimes = remoteConfig.getDouble(RemoteConfigKey.SUPPORT_DISPLAY_REQUEST_TIMES).toInt()
@@ -1174,44 +982,19 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
     }
 
     public override fun onPause() {
-        when (remoteConfig.getString(RemoteConfigKey.AD_NETWORK)) {
-            RemoteConfigKey.AdNetwork.IMOBILE -> {
-                ImobileSdkAd.stop(IMOBILE_BANNER_SID)
-            }
-
-            RemoteConfigKey.AdNetwork.IRONSOURCE -> {
-                IronSource.onPause(this)
-            }
-        }
+        adController.onPause(this)
         super.onPause()
     }
 
     public override fun onResume() {
-        when (remoteConfig.getString(RemoteConfigKey.AD_NETWORK)) {
-            RemoteConfigKey.AdNetwork.IMOBILE -> {
-                ImobileSdkAd.start(IMOBILE_BANNER_SID)
-            }
-
-            RemoteConfigKey.AdNetwork.IRONSOURCE -> {
-                IronSource.onResume(this)
-            }
-        }
+        adController.onResume(this)
         super.onResume()
     }
 
     public override fun onDestroy() {
         detectIntent.resetContexts()
         scope.coroutineContext.cancel()
-        when (remoteConfig.getString(RemoteConfigKey.AD_NETWORK)) {
-            RemoteConfigKey.AdNetwork.IMOBILE -> {
-                ImobileSdkAd.stop(IMOBILE_BANNER_SID)
-                ImobileSdkAd.stop(IMOBILE_INTERSTITIAL_SID)
-            }
-
-            RemoteConfigKey.AdNetwork.IRONSOURCE -> {
-                IronSource.destroyBanner(ironSourceBannerLayout)
-            }
-        }
+        adController.onDestroy(this)
         super.onDestroy()
     }
 

--- a/app/src/main/java/com/aqua_ix/youbimiku/ads/AdController.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/ads/AdController.kt
@@ -1,0 +1,35 @@
+package com.aqua_ix.youbimiku.ads
+
+import androidx.appcompat.app.AppCompatActivity
+
+/**
+ * 広告SDKの呼び出しを隠蔽するインターフェース。
+ * `ads` フレーバーには実際に広告を表示する実装、`noAds` フレーバーには何もしない実装を置くことで、
+ * 呼び出し側（MainActivity）は広告SDKのクラスを直接参照しない。
+ */
+interface AdController {
+    /**
+     * 広告ネットワークを初期化する。
+     *
+     * @param adNetwork RemoteConfigの`ad_network`の値
+     * @param actionBarSize バナーをアクションバーの下に表示するために上マージンへ加算する高さ
+     * @param onBannerHeightChanged バナーの表示状態が変わったときに、確保すべき高さを通知する
+     */
+    fun setup(
+        activity: AppCompatActivity,
+        adNetwork: String,
+        actionBarSize: Int,
+        onBannerHeightChanged: (Int) -> Unit
+    )
+
+    /**
+     * インタースティシャル広告を表示する。初期化済みの広告ネットワークがない場合は何もしない。
+     */
+    fun showInterstitial(activity: AppCompatActivity)
+
+    fun onResume(activity: AppCompatActivity)
+
+    fun onPause(activity: AppCompatActivity)
+
+    fun onDestroy(activity: AppCompatActivity)
+}

--- a/app/src/noAds/AndroidManifest.xml
+++ b/app/src/noAds/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <!-- 広告SDKを同梱しないため、依存ライブラリが差し込む広告ID権限も取り除く -->
+    <uses-permission
+        android:name="com.google.android.gms.permission.AD_ID"
+        tools:node="remove" />
+
+</manifest>

--- a/app/src/noAds/java/com/aqua_ix/youbimiku/ads/AdControllerFactory.kt
+++ b/app/src/noAds/java/com/aqua_ix/youbimiku/ads/AdControllerFactory.kt
@@ -1,0 +1,8 @@
+package com.aqua_ix.youbimiku.ads
+
+/**
+ * `noAds` フレーバー用のファクトリ。広告SDKを同梱しないため何もしない実装を返す。
+ */
+object AdControllerFactory {
+    fun create(): AdController = NoOpAdController()
+}

--- a/app/src/noAds/java/com/aqua_ix/youbimiku/ads/NoOpAdController.kt
+++ b/app/src/noAds/java/com/aqua_ix/youbimiku/ads/NoOpAdController.kt
@@ -1,0 +1,30 @@
+package com.aqua_ix.youbimiku.ads
+
+import android.util.Log
+import androidx.appcompat.app.AppCompatActivity
+
+/**
+ * 広告SDKを同梱しない`noAds`フレーバー向けの、何もしない実装。
+ */
+class NoOpAdController : AdController {
+    override fun setup(
+        activity: AppCompatActivity,
+        adNetwork: String,
+        actionBarSize: Int,
+        onBannerHeightChanged: (Int) -> Unit
+    ) {
+        Log.d(TAG, "Ad network is disabled by flavor.")
+    }
+
+    override fun showInterstitial(activity: AppCompatActivity) {}
+
+    override fun onResume(activity: AppCompatActivity) {}
+
+    override fun onPause(activity: AppCompatActivity) {}
+
+    override fun onDestroy(activity: AppCompatActivity) {}
+
+    companion object {
+        val TAG = NoOpAdController::class.java.name.toString()
+    }
+}


### PR DESCRIPTION
Closes #93

## 概要

広告SDKが `noAds` フレーバーにも同梱されていた問題を解消し、`MainActivity` から広告SDKへの直接依存を取り除きました。

## 変更内容

### 依存関係（`app/build.gradle.kts`）

- `libs/*.jar`（iMobile SDK）と `com.ironsource.sdk:mediationsdk` を `adsImplementation` に移動
- 広告ID取得用の `play-services-appset` / `play-services-ads-identifier` も `adsImplementation` に移動
- `implementation(fileTree(...))` と `implementation(files("libs/imobileSdkAds.jar"))` で二重に入っていた iMobile SDK の指定を 1 つに統合

### `AdController` の導入

- `app/src/main/.../ads/AdController.kt`: 広告SDK呼び出しを隠蔽するインターフェース
- `app/src/ads/.../ads/AdNetworkController.kt`: iMobile / IronSource を呼ぶ実装（既存ロジックをそのまま移動）
- `app/src/noAds/.../ads/NoOpAdController.kt`: 何もしない実装
- 各フレーバーの `AdControllerFactory` が実装を返す
- `MainActivity` は広告SDKを import しなくなり、`BuildConfig.FLAVOR` による分岐も不要になりました

あわせて、`AdNetworkController` は**実際に初期化した広告ネットワーク**を保持し、`onPause` / `onResume` / `onDestroy` / インタースティシャル表示はその値で分岐するようにしました。これにより、RemoteConfig の `ad_network` が `ironsource` でもバナー未生成のまま `IronSource.destroyBanner()` を呼んで `UninitializedPropertyAccessException` になる経路がなくなります。

### マニフェスト

- `main` から `AD_ID` 権限と i-mobile 用 `meta-data` を削除
- `app/src/ads/AndroidManifest.xml`: `AD_ID` 権限と i-mobile 用 `meta-data` を宣言
- `app/src/noAds/AndroidManifest.xml`: 依存ライブラリ（Firebase Analytics 等）がマージしてくる `AD_ID` 権限を `tools:node="remove"` で除去
- なお `main` の `AD_ID` 権限は権限名の末尾に半角スペースが入った状態（`"...AD_ID "`）でした。`ads` 側では正しい名前で宣言し直しています。

### ドキュメント

`CLAUDE.md` の Build Configuration / Key Layers / Ad Integration を実装に合わせて更新（別コミット）。

## ビルド結果

`assembleAdsDebug` / `assembleNoAdsDebug` / `testAdsDebugUnitTest` / `testNoAdsDebugUnitTest` / `lint` すべて BUILD SUCCESSFUL。新規の警告は出ていません（IronSource SDK の deprecation 警告は移動前から同一）。

## adb 検証（emulator-5554 / Android 16 / 1080x2424）

デバッグビルドの APK を実機（エミュレータ）にインストールして確認しました。

| 受け入れ条件 | 結果 |
| --- | --- |
| `noAds` の成果物に広告SDKのクラスが含まれない | **検証済み**（下記） |
| `ad_network=ironsource` の状態で noAds 版を起動→終了してもクラッシュしない | **検証済み** |
| `MainActivity` が広告SDKのクラスを直接参照していない | **検証済み**（import 削除・`apkanalyzer` の dex 出力でも参照なし） |
| `CLAUDE.md` の記述が実装と一致している | **検証済み** |

### 広告SDKクラスの非同梱

`apkanalyzer dex packages --defined-only` の出力を比較しました。

| | `com.ironsource.*` クラス数 | `jp.co.imobile.*` クラス数 | APKサイズ |
| --- | --- | --- | --- |
| `app-ads-debug.apk` | 3248 | 85 | 21.8MB |
| `app-noAds-debug.apk` | **0** | **0** | 20.2MB |

`noAds` 側に残る `IMOBILE` / `IRONSOURCE` の文字列は `BuildConfig` のフィールド名と `RemoteConfigKey.AdNetwork` の定数のみで、SDKクラスは含まれません。

マージ後のマニフェストも比較し、`noAds` からは `com.google.android.gms.permission.AD_ID` と IronSource が差し込む component が消えていることを確認しました（実機ログにも `AdvertisingIdSettings: Package ... failed Ad Id permission check` が出て、広告IDへアクセスできない状態になっています）。

### 動作確認

- `noAds`: 起動 → 初回ダイアログ通過 → チャット画面表示 → バナーなし → バックキーで終了。`NoOpAdController: Ad network is disabled by flavor.` のみが出力され、`FATAL` / `UninitializedPropertyAccessException` / `NoClassDefFoundError` はゼロ。RemoteConfig の `ad_network` が空だと経路を通らないため、ローカルの `remote_config_defaults.xml` を一時的に `ironsource` に書き換えたビルドでも起動→終了を確認（この一時変更はコミットしていません）。
- `ads`（`ad_network=ironsource`）: IronSource SDK が初期化され（`IntegrationHelper: >>>> IronSource - VERIFIED`）、インタースティシャルの `onAdReady` を受信。GPTモデル＋`ad_display_request_times=1` でメッセージを送信し、**実際にインタースティシャル広告が表示される**ことをスクリーンショットで確認（`IronSource.showInterstitial` → `interstitial show succeeded`）。終了時のクラッシュなし。
- `ads`（`ad_network=imobile`）: `ImobileSdkAd` の登録・表示要求が走り、リスナーが `onFailed: NOT_DELIVERY_AD` を受信（エミュレータでは配信なし）。コールバック経路が新実装でも動いていることを確認。
- `ads`（`ad_network` 未設定＝本番の現在値）: `Ad network is not configured:` のログのみで、起動・終了ともクラッシュなし。

### 既存挙動との比較

IronSource バナーの `errorCode:602 init() had failed` は本 PR 由来ではないことを確認するため、`main`（8dd5f0c）から同条件でビルドした APK でも同じログが出ることを確認しました（`MainActivity: IronSource banner load failed: errorCode:602, errorMessage:init() had failed`）。呼び出し順序は変更していません。

### 未検証

- `assembleNoAdsRelease` の成果物そのものは未確認です（release は minify 無効・同一の依存構成なので、debug APK での dex 検証と同じ結果になります）
- エミュレータではバナー広告の配信がなかったため、**バナー**が実際に描画される様子は未確認です（インタースティシャルは表示確認済み）
