### PR TITLE
アバターモードのレスポンスヘッダーをログ出力しないようにする

### DIFF
--- a/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
@@ -641,9 +641,10 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
                     headers.forEach { connection.setRequestProperty(it.key, it.value) }
                     connection.connect()
 
+                    // レスポンスヘッダーには Cloudflare Access の認証トークンが含まれるため出力しない
                     Log.d(
                         TAG,
-                        "WebResourceResponse: ${connection.contentType}, ${connection.contentEncoding}, ${connection.inputStream}, ${connection.headerFields}"
+                        "WebResourceResponse: ${connection.responseCode}, ${connection.contentType}, ${connection.contentEncoding}"
                     )
 
                     WebResourceResponse(


### PR DESCRIPTION
Closes #105

## 背景

アバターモードの `shouldInterceptRequest` で、レスポンス内容のデバッグログに
`connection.headerFields` を丸ごと出力していた。Cloudflare Access は認証成功時に
`Set-Cookie: CF_Authorization=<JWT>` を返すため、この認証トークンが logcat に
平文で記録されていた。`BuildConfig.DEBUG` ガードが無く、R8/minify も無効なので
リリースビルドでも出力される状態だった。

## 変更内容

`MainActivity.kt` の `shouldInterceptRequest` 内のログ出力を見直した。

- `connection.headerFields` の出力を削除（認証トークンの漏洩経路）
- `connection.inputStream` の出力を削除（`toString()` がデバッグ価値なし）
- 代わりに `responseCode` を出力し、`contentType` / `contentEncoding` は維持
- 意図が失われないようコメントを追記

リクエストヘッダーに付与している `CF-Access-Client-Id` / `CF-Access-Client-Secret`
については、リポジトリ全体を grep して他にログ出力箇所が無いことを確認済み
（`avatarClientId` / `avatarClientSecret` はヘッダー組み立てと初期化チェックにしか
使われておらず、値をログに出す箇所は無い）。

ログ基盤の整備（#102）、R8/minify の有効化、`shouldInterceptRequest` の
メインスレッド同期通信（#98）、WebView ライフサイクル（#92）は本 PR のスコープ外。

## 検証

エミュレータ（Pixel 9a / Android 16、ads デバッグビルド）で修正前後を比較した。
なお、以下の件数は grep のヒット行数のみで、トークンの実値は記載しない。

修正前:

- アバターモードを開くと `logcat` に `CF_Authorization` / `Set-Cookie` を含む行が 16 件ヒット

修正後（`logcat -c` してから同じ操作）:

- `CF_Authorization` / `CF-Access` / `Set-Cookie` のヒット 0 件
- JWT らしき文字列（`eyJ...`）のヒット 0 件
- `WebResourceResponse:` のログ自体は 18 件出力されており、内容は
  ステータスコード・content type・content encoding のみ
- アバターページは従来どおり読み込まれ、3D アバターが表示されることを確認

ビルド確認:

- `gradlew compileAdsDebugKotlin compileNoAdsDebugKotlin` BUILD SUCCESSFUL