### PR TITLE
AI応答の失敗表示と応答待ち中の送信破棄を修正

### DIFF
--- a/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
@@ -36,6 +36,7 @@ import com.aallam.openai.api.chat.ChatCompletionRequest
 import com.aallam.openai.api.chat.ChatMessage
 import com.aallam.openai.api.chat.ChatRole
 import com.aallam.openai.api.core.FinishReason
+import com.aallam.openai.api.exception.OpenAIIOException
 import com.aallam.openai.api.model.ModelId
 import com.aallam.openai.client.OpenAI
 import com.aallam.openai.client.OpenAIConfig
@@ -69,10 +70,12 @@ import com.aqua_ix.youbimiku.database.messageToEntity
 import com.aqua_ix.youbimiku.databinding.ActivityMainBinding
 import com.github.bassaer.chatmessageview.model.Message
 import com.google.android.play.core.review.ReviewManagerFactory
+import com.google.api.gax.rpc.UnavailableException
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
 import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.ValueEventListener
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -82,6 +85,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URL
 
@@ -92,7 +96,9 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
 
     private lateinit var binding: ActivityMainBinding
     private lateinit var detectIntent: DetectIntent
-    private lateinit var openAI: OpenAI
+
+    // 初期化はRemoteConfigとFirebaseの取得後になるため、未初期化を判別できるようにnullableで持つ
+    private var openAI: OpenAI? = null
     private lateinit var firebaseDatabase: FirebaseDatabase
     private lateinit var appDatabase: AppDatabase
     private lateinit var navMenu: Menu
@@ -123,7 +129,15 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
     private val job = SupervisorJob()
     private val exceptionHandler: CoroutineExceptionHandler =
         CoroutineExceptionHandler { _, throwable ->
-            Log.e(TAG, throwable.message.toString())
+            Log.e(TAG, "Unhandled error: $throwable")
+            // ハンドリング漏れがあっても失敗が伝わるようにする。ログだけだと
+            // ユーザーには「ミクが黙ったまま」にしか見えない
+            runOnUiThread {
+                if (isDestroyed || isFinishing) {
+                    return@runOnUiThread
+                }
+                showErrorMessage(getErrorMessage(throwable))
+            }
         }
     private val scope = CoroutineScope(Dispatchers.Default + job + exceptionHandler)
     private var openAITaskJob: Job? = null
@@ -247,12 +261,8 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
     }
 
     private fun onOpenAIError() {
-        val error = Message.Builder()
-            .setUser(mikuAccount)
-            .setRight(false)
-            .setText(getString(R.string.message_error_openai))
-            .build()
-        binding.chatView.receive(error)
+        openAI = null
+        showErrorMessage(getString(R.string.message_error_openai))
         mikuAccount.setName(getString(R.string.miku_name))
         setAIModel(this, AIModelConfig.DIALOG_FLOW)
         if (::navMenu.isInitialized) {
@@ -284,23 +294,24 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
     }
 
     private fun showActionSheet(message: Message) {
-        val options = if (message.user.getId() == userAccount.getId()) {
-            arrayOf(getString(R.string.copy_message))
+        val isUserMessage = message.user.getId() == userAccount.getId()
+        val options = if (isUserMessage) {
+            arrayOf(getString(R.string.copy_message), getString(R.string.resend_message))
         } else {
             arrayOf(getString(R.string.copy_message), getString(R.string.report_message))
         }
         AlertDialog.Builder(this)
             .setItems(options) { _, which ->
-                when (which) {
-                    0 -> message.text?.let { copyMessageToClipboard(it) }
-                    1 -> message.text?.let {
-                        ReportUtil.showReportReasonDialog(
-                            this,
-                            it,
-                            userAccount.getName() ?: "",
-                            scope
-                        )
-                    }
+                val text = message.text ?: return@setItems
+                when {
+                    which == 0 -> copyMessageToClipboard(text)
+                    isUserMessage -> resendMessage(text)
+                    else -> ReportUtil.showReportReasonDialog(
+                        this,
+                        text,
+                        userAccount.getName() ?: "",
+                        scope
+                    )
                 }
             }
             .show()
@@ -991,22 +1002,56 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
 
 
     override fun onClick(v: View) {
-        if (binding.chatView.inputText.isEmpty()) {
+        val text = binding.chatView.inputText
+        if (text.isEmpty()) {
             return
         }
+        if (!canSendRequest()) {
+            // 送信できない場合は入力内容を消さず、打ち直さずに再送信できるようにする
+            return
+        }
+
         val send = Message.Builder()
             .setUser(userAccount)
             .setRight(true)
-            .setText(binding.chatView.inputText)
+            .setText(text)
             .hideIcon(true)
             .build()
-        sendRequest(binding.chatView.inputText)
+        sendRequest(text)
         binding.chatView.send(send)
         binding.chatView.inputText = ""
 
         scope.launch {
             appDatabase.messageDao().insert(messageToEntity(send))
         }
+
+        // 送信したメッセージ数を数えるのはこのタイミングだけ。
+        // 送信されなかったメッセージや再送信を数えないようにする
+        showInterstitialIfNeeded()
+        showSupportDialogIfNeeded()
+    }
+
+    /**
+     * 送信できる状態かどうかを返す。送信できない場合はその理由を画面に表示する。
+     */
+    private fun canSendRequest(): Boolean {
+        if (getAIModel(this) == AIModelConfig.OPEN_AI.name && openAI == null) {
+            // RemoteConfigとFirebaseからの初期化がまだ終わっていない
+            Log.w(TAG, "OpenAI is not initialized yet.")
+            Toast.makeText(this, R.string.message_preparing, Toast.LENGTH_SHORT).show()
+            return false
+        }
+        return true
+    }
+
+    /**
+     * 応答が返らなかったメッセージを、履歴に増やさずもう一度送り直す。
+     */
+    private fun resendMessage(text: String) {
+        if (!canSendRequest()) {
+            return
+        }
+        sendRequest(text)
     }
 
     private fun sendRequest(text: String) {
@@ -1023,18 +1068,66 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
                         return@launch
                     }
                     openAITaskJob = launch {
-                        openAITask(text)
+                        runAITask { openAITask(text) }
                     }
                 }
 
             else ->
                 scope.launch {
-                    dialogFlowTask(text)
+                    runAITask { dialogFlowTask(text) }
                 }
         }
+    }
 
-        showInterstitialIfNeeded()
-        showSupportDialogIfNeeded()
+    /**
+     * AI応答の取得を実行し、失敗した場合はエラーを会話上に表示する。
+     * ここで受け止めないとCoroutineExceptionHandlerでログに落ちるだけになり、
+     * ユーザーには応答が来ないことしか分からない。
+     */
+    private suspend fun runAITask(task: suspend () -> Unit) {
+        try {
+            task()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.e(TAG, "AI request error: $e")
+            withContext(Dispatchers.Main) {
+                if (isDestroyed || isFinishing) {
+                    return@withContext
+                }
+                showErrorMessage(getErrorMessage(e))
+            }
+        }
+    }
+
+    /**
+     * ミク側の吹き出しとしてエラーを表示する。
+     * 再起動後には意味を持たないため、履歴（DB）には保存しない。
+     */
+    private fun showErrorMessage(text: String) {
+        val error = Message.Builder()
+            .setUser(mikuAccount)
+            .setRight(false)
+            .setText(text)
+            .build()
+        binding.chatView.receive(error)
+    }
+
+    /**
+     * 例外の種別に応じたエラー文言を返す。
+     * 通信エラーはライブラリ独自の例外に包まれるため、causeを辿って判定する。
+     */
+    private fun getErrorMessage(throwable: Throwable): String {
+        val causes = generateSequence(throwable) { if (it.cause === it) null else it.cause }
+            .take(MAX_CAUSE_DEPTH)
+        val isNetworkError = causes.any {
+            it is IOException || it is OpenAIIOException || it is UnavailableException
+        }
+        return if (isNetworkError) {
+            getString(R.string.message_error)
+        } else {
+            getString(R.string.message_error_ai_response)
+        }
     }
 
     /**
@@ -1085,10 +1178,29 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
     private suspend fun dialogFlowTask(text: String) {
         val response = detectIntent.send(text)
         Log.d(TAG, "response: $response")
+        receiveMessage(response)
+    }
+
+    /**
+     * ミクの応答を表示して履歴に保存する。
+     * 応答が空の場合は黙って捨てず、状態が伝わるようにエラーとして扱う。
+     */
+    private suspend fun receiveMessage(text: String?) {
+        if (text.isNullOrEmpty()) {
+            Log.e(TAG, "Response is empty.")
+            withContext(Dispatchers.Main) {
+                if (isDestroyed || isFinishing) {
+                    return@withContext
+                }
+                showErrorMessage(getString(R.string.message_error_empty_response))
+            }
+            return
+        }
+
         val receivedMessage = Message.Builder()
             .setUser(mikuAccount)
             .setRight(false)
-            .setText(response)
+            .setText(text)
             .build()
         withContext(Dispatchers.Main) {
             binding.chatView.receive(receivedMessage)
@@ -1097,6 +1209,19 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
     }
 
     private suspend fun openAITask(text: String) {
+        val client = openAI
+        if (client == null) {
+            // 送信前にも確認しているが、初期化が外れた場合にも黙って終わらないようにする
+            Log.e(TAG, "OpenAI is not initialized.")
+            withContext(Dispatchers.Main) {
+                if (isDestroyed || isFinishing) {
+                    return@withContext
+                }
+                showErrorMessage(getString(R.string.message_preparing))
+            }
+            return
+        }
+
         val maxLength = RemoteConfigProvider.maxUserTextLength
         val sendText = if (text.length <= maxLength) text else text.substring(0, maxLength)
         Log.d(TAG, "sendText: $sendText")
@@ -1121,32 +1246,22 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
             ),
             maxTokens = maxTokens
         )
-        val completion = openAI.chatCompletion(chatCompletionRequest)
+        val completion = client.chatCompletion(chatCompletionRequest)
         Log.d(TAG, "completion: $completion")
         val choice = completion.choices.first()
-        choice.message.content.let {
-            val response = it?.replace("^$|\n", "")
-            Log.d(TAG, "response: $response")
-            val result = if (choice.finishReason == FinishReason.Length) {
-                "$response…"
-            } else {
-                response
-            }
-            Log.d(TAG, "result: $result")
-            if (result.isNullOrEmpty()) {
-                return
-            }
-            openAIPreviousResponse = result
-            val receivedMessage = Message.Builder()
-                .setUser(mikuAccount)
-                .setRight(false)
-                .setText(result)
-                .build()
-            withContext(Dispatchers.Main) {
-                binding.chatView.receive(receivedMessage)
-            }
-            appDatabase.messageDao().insert(messageToEntity(receivedMessage))
+        val response = choice.message.content?.replace("^$|\n", "")
+        Log.d(TAG, "response: $response")
+        val result = when {
+            // 応答が空のまま末尾に記号を足すと空でなくなってしまうので先に判定する
+            response.isNullOrEmpty() -> null
+            choice.finishReason == FinishReason.Length -> "$response…"
+            else -> response
         }
+        Log.d(TAG, "result: $result")
+        if (result != null) {
+            openAIPreviousResponse = result
+        }
+        receiveMessage(result)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -1199,5 +1314,8 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
 
         private const val STATE_AVATAR_MODE = "state_avatar_mode"
         private const val STATE_AVATAR_URL = "state_avatar_url"
+
+        // 例外の原因を辿る深さの上限。cause が循環していても止まるようにする
+        private const val MAX_CAUSE_DEPTH = 10
     }
 }

--- a/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
@@ -79,7 +79,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
@@ -139,10 +138,6 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
 
     // 応答待ちかどうか。判定と更新をメインスレッドに揃えて、連続送信で競合しないようにする
     private var isSending = false
-
-    // 実行中のリクエストを途中で止めるためだけに持つ。
-    // 応答待ちの判定にJobを使うと連続タップで競合するのでisSendingで行う
-    private var aiTaskJob: Job? = null
 
     // 応答待ちを示すだけの吹き出し。履歴には残さないので消すために参照を持つ
     private var typingMessage: Message? = null
@@ -267,10 +262,8 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
 
     private fun onOpenAIError() {
         openAI = null
-        // 実行中のリクエストは使えなくなったクライアントのものなので止める。
-        // 止めずに応答待ちだけ解除すると、あとから届いた応答が新しい会話に割り込む。
-        // 解除はrunAITaskのfinallyが行うので、送信ボタンもここで戻る
-        aiTaskJob?.cancel()
+        // 応答待ちの状態はここでは触らない。実行中のリクエストはrunAITaskのfinallyが
+        // 必ず解除するので、割り込んで解除するとあとから届いた応答が新しい会話に混ざる
         showErrorMessage(getString(R.string.message_error_openai))
         mikuAccount.setName(getString(R.string.miku_name))
         setAIModel(this, AIModelConfig.DIALOG_FLOW)
@@ -1083,7 +1076,7 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
         // コルーチンの中で判定すると、連続タップでどちらもすり抜けることがある
         val aiModel = getAIModel(this)
         setSendingState(true)
-        aiTaskJob = scope.launch {
+        scope.launch {
             runAITask {
                 when (aiModel) {
                     AIModelConfig.OPEN_AI.name -> openAITask(text)
@@ -1145,6 +1138,9 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
                 if (isDestroyed || isFinishing) {
                     return@withContext
                 }
+                // 応答待ちの吹き出しを消してからエラーを並べる。finallyでも解除するが、
+                // 表示のたびに待ち状態が残らないようここで済ませる
+                setSendingState(false)
                 showErrorMessage(getErrorMessage(e))
             }
         } finally {
@@ -1162,10 +1158,16 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
     /**
      * ミク側の吹き出しとしてエラーを表示する。
      * 再起動後には意味を持たないため、履歴（DB）には保存しない。
+     *
+     * 応答待ちの吹き出しはsetSendingStateだけが出し入れする。ここで消すと、
+     * リクエストと無関係なエラー（onOpenAIErrorなど）でも消えてしまい、
+     * 応答待ちなのに何も起きていないように見える。
      */
     private fun showErrorMessage(text: String) {
-        // 応答待ちの吹き出しを残したままエラーを並べないように先に消す
-        hideTypingIndicator()
+        if (isDestroyed || isFinishing) {
+            // Firebaseのリスナは破棄後にも呼ばれ得るので、ここでまとめて弾く
+            return
+        }
         val error = Message.Builder()
             .setUser(mikuAccount)
             .setRight(false)
@@ -1265,9 +1267,14 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
             .setText(text)
             .build()
         withContext(Dispatchers.Main) {
+            if (isDestroyed || isFinishing) {
+                return@withContext
+            }
+            // 応答の吹き出しの下に応答待ちの吹き出しが残らないよう先に消す
             hideTypingIndicator()
             binding.chatView.receive(receivedMessage)
         }
+        // 表示できなくても会話は成立しているので履歴には残す
         appDatabase.messageDao().insert(messageToEntity(receivedMessage))
     }
 

--- a/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
@@ -79,7 +79,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
@@ -133,14 +133,20 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
             // ハンドリング漏れがあっても失敗が伝わるようにする。ログだけだと
             // ユーザーには「ミクが黙ったまま」にしか見えない
             runOnUiThread {
-                if (isDestroyed || isFinishing) {
+                if (isDestroyed || isFinishing || !isSending) {
                     return@runOnUiThread
                 }
+                setSendingState(false)
                 showErrorMessage(getErrorMessage(throwable))
             }
         }
     private val scope = CoroutineScope(Dispatchers.Default + job + exceptionHandler)
-    private var openAITaskJob: Job? = null
+
+    // 応答待ちかどうか。判定と更新をメインスレッドに揃えて、連続送信で競合しないようにする
+    private var isSending = false
+
+    // 応答待ちを示すだけの吹き出し。履歴には残さないので消すために参照を持つ
+    private var typingMessage: Message? = null
 
     private var actionBarSize = 0
 
@@ -1017,13 +1023,15 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
             .setText(text)
             .hideIcon(true)
             .build()
-        sendRequest(text)
         binding.chatView.send(send)
         binding.chatView.inputText = ""
 
         scope.launch {
             appDatabase.messageDao().insert(messageToEntity(send))
         }
+
+        // 応答待ちの吹き出しが送信した吹き出しより先に並ばないよう、表示のあとに送る
+        sendRequest(text)
 
         // 送信したメッセージ数を数えるのはこのタイミングだけ。
         // 送信されなかったメッセージや再送信を数えないようにする
@@ -1035,6 +1043,12 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
      * 送信できる状態かどうかを返す。送信できない場合はその理由を画面に表示する。
      */
     private fun canSendRequest(): Boolean {
+        if (isSending) {
+            // 応答待ちの間に送ると、応答が来ないメッセージが履歴に残ってしまう
+            Log.w(TAG, "The previous request is still running.")
+            Toast.makeText(this, R.string.message_waiting_response, Toast.LENGTH_SHORT).show()
+            return false
+        }
         if (getAIModel(this) == AIModelConfig.OPEN_AI.name && openAI == null) {
             // RemoteConfigとFirebaseからの初期化がまだ終わっていない
             Log.w(TAG, "OpenAI is not initialized yet.")
@@ -1061,22 +1075,54 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
             return
         }
 
-        when (getAIModel(this)) {
-            AIModelConfig.OPEN_AI.name ->
-                scope.launch {
-                    if (openAITaskJob?.isActive == true) {
-                        return@launch
-                    }
-                    openAITaskJob = launch {
-                        runAITask { openAITask(text) }
-                    }
+        // 応答待ちの判定と開始をメインスレッドで済ませてから起動する。
+        // コルーチンの中で判定すると、連続タップでどちらもすり抜けることがある
+        val aiModel = getAIModel(this)
+        setSendingState(true)
+        scope.launch {
+            runAITask {
+                when (aiModel) {
+                    AIModelConfig.OPEN_AI.name -> openAITask(text)
+                    else -> dialogFlowTask(text)
                 }
-
-            else ->
-                scope.launch {
-                    runAITask { dialogFlowTask(text) }
-                }
+            }
         }
+    }
+
+    /**
+     * 応答待ちかどうかを切り替える。メインスレッドからのみ呼ぶ。
+     */
+    private fun setSendingState(isSending: Boolean) {
+        this.isSending = isSending
+        binding.chatView.setEnableSendButton(!isSending)
+        if (isSending) {
+            showTypingIndicator()
+        } else {
+            hideTypingIndicator()
+        }
+    }
+
+    /**
+     * ミクが応答を考えていることを示す吹き出しを表示する。
+     * 応答待ちの間だけのものなので履歴（DB）には保存しない。
+     */
+    private fun showTypingIndicator() {
+        if (typingMessage != null) {
+            return
+        }
+        val typing = Message.Builder()
+            .setUser(mikuAccount)
+            .setRight(false)
+            .setText(getString(R.string.message_typing))
+            .build()
+        typingMessage = typing
+        binding.chatView.receive(typing)
+    }
+
+    private fun hideTypingIndicator() {
+        val typing = typingMessage ?: return
+        typingMessage = null
+        binding.chatView.getMessageView().remove(typing)
     }
 
     /**
@@ -1097,6 +1143,15 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
                 }
                 showErrorMessage(getErrorMessage(e))
             }
+        } finally {
+            // 失敗しても応答待ちのまま固まらないように必ず解除する。
+            // scopeのキャンセル後でも実行できるようNonCancellableにする
+            withContext(NonCancellable + Dispatchers.Main) {
+                if (isDestroyed || isFinishing) {
+                    return@withContext
+                }
+                setSendingState(false)
+            }
         }
     }
 
@@ -1105,6 +1160,8 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
      * 再起動後には意味を持たないため、履歴（DB）には保存しない。
      */
     private fun showErrorMessage(text: String) {
+        // 応答待ちの吹き出しを残したままエラーを並べないように先に消す
+        hideTypingIndicator()
         val error = Message.Builder()
             .setUser(mikuAccount)
             .setRight(false)
@@ -1203,6 +1260,7 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
             .setText(text)
             .build()
         withContext(Dispatchers.Main) {
+            hideTypingIndicator()
             binding.chatView.receive(receivedMessage)
         }
         appDatabase.messageDao().insert(messageToEntity(receivedMessage))

--- a/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
@@ -129,16 +129,10 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
     private val job = SupervisorJob()
     private val exceptionHandler: CoroutineExceptionHandler =
         CoroutineExceptionHandler { _, throwable ->
-            Log.e(TAG, "Unhandled error: $throwable")
-            // ハンドリング漏れがあっても失敗が伝わるようにする。ログだけだと
-            // ユーザーには「ミクが黙ったまま」にしか見えない
-            runOnUiThread {
-                if (isDestroyed || isFinishing || !isSending) {
-                    return@runOnUiThread
-                }
-                setSendingState(false)
-                showErrorMessage(getErrorMessage(throwable))
-            }
+            // AI応答の失敗はrunAITaskで受け止めて表示するので、ここに来るのは
+            // 履歴の保存や報告など送信とは無関係な処理の失敗。応答待ちの状態を
+            // 触ると実行中のリクエストの状態を壊すため、ログだけに留める
+            Log.e(TAG, "Unhandled error", throwable)
         }
     private val scope = CoroutineScope(Dispatchers.Default + job + exceptionHandler)
 
@@ -268,6 +262,11 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
 
     private fun onOpenAIError() {
         openAI = null
+        if (isSending) {
+            // 実行中のリクエストは使えなくなったクライアントのものなので応答は返らない。
+            // 解除しないと送信ボタンが戻らないまま入力できなくなる
+            setSendingState(false)
+        }
         showErrorMessage(getString(R.string.message_error_openai))
         mikuAccount.setName(getString(R.string.miku_name))
         setAIModel(this, AIModelConfig.DIALOG_FLOW)
@@ -1009,7 +1008,8 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
 
     override fun onClick(v: View) {
         val text = binding.chatView.inputText
-        if (text.isEmpty()) {
+        if (text.isBlank()) {
+            // 空白だけの入力はリクエストにならないので、吹き出しも履歴も増やさない
             return
         }
         if (!canSendRequest()) {
@@ -1136,7 +1136,7 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            Log.e(TAG, "AI request error: $e")
+            Log.e(TAG, "AI request error", e)
             withContext(Dispatchers.Main) {
                 if (isDestroyed || isFinishing) {
                     return@withContext
@@ -1241,9 +1241,10 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
     /**
      * ミクの応答を表示して履歴に保存する。
      * 応答が空の場合は黙って捨てず、状態が伝わるようにエラーとして扱う。
+     * 改行や空白だけの応答も吹き出しが空に見えるだけなので空として扱う。
      */
     private suspend fun receiveMessage(text: String?) {
-        if (text.isNullOrEmpty()) {
+        if (text.isNullOrBlank()) {
             Log.e(TAG, "Response is empty.")
             withContext(Dispatchers.Main) {
                 if (isDestroyed || isFinishing) {
@@ -1307,11 +1308,11 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
         val completion = client.chatCompletion(chatCompletionRequest)
         Log.d(TAG, "completion: $completion")
         val choice = completion.choices.first()
-        val response = choice.message.content?.replace("^$|\n", "")
+        val response = choice.message.content
         Log.d(TAG, "response: $response")
         val result = when {
             // 応答が空のまま末尾に記号を足すと空でなくなってしまうので先に判定する
-            response.isNullOrEmpty() -> null
+            response.isNullOrBlank() -> null
             choice.finishReason == FinishReason.Length -> "$response…"
             else -> response
         }

--- a/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/MainActivity.kt
@@ -79,6 +79,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
@@ -138,6 +139,10 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
 
     // 応答待ちかどうか。判定と更新をメインスレッドに揃えて、連続送信で競合しないようにする
     private var isSending = false
+
+    // 実行中のリクエストを途中で止めるためだけに持つ。
+    // 応答待ちの判定にJobを使うと連続タップで競合するのでisSendingで行う
+    private var aiTaskJob: Job? = null
 
     // 応答待ちを示すだけの吹き出し。履歴には残さないので消すために参照を持つ
     private var typingMessage: Message? = null
@@ -262,11 +267,10 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
 
     private fun onOpenAIError() {
         openAI = null
-        if (isSending) {
-            // 実行中のリクエストは使えなくなったクライアントのものなので応答は返らない。
-            // 解除しないと送信ボタンが戻らないまま入力できなくなる
-            setSendingState(false)
-        }
+        // 実行中のリクエストは使えなくなったクライアントのものなので止める。
+        // 止めずに応答待ちだけ解除すると、あとから届いた応答が新しい会話に割り込む。
+        // 解除はrunAITaskのfinallyが行うので、送信ボタンもここで戻る
+        aiTaskJob?.cancel()
         showErrorMessage(getString(R.string.message_error_openai))
         mikuAccount.setName(getString(R.string.miku_name))
         setAIModel(this, AIModelConfig.DIALOG_FLOW)
@@ -1079,7 +1083,7 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, DialogListener {
         // コルーチンの中で判定すると、連続タップでどちらもすり抜けることがある
         val aiModel = getAIModel(this)
         setSendingState(true)
-        scope.launch {
+        aiTaskJob = scope.launch {
             runAITask {
                 when (aiModel) {
                     AIModelConfig.OPEN_AI.name -> openAITask(text)

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -13,6 +13,8 @@
     <string name="message_error_ai_response">ごめんなさい、うまく答えられませんでした。少し待ってから、もう一度話しかけてください。</string>
     <string name="message_error_empty_response">ごめんなさい、返す言葉が思いつきませんでした。もう一度話しかけてください。</string>
     <string name="message_preparing">準備中です。少し待ってから送信してください。</string>
+    <string name="message_waiting_response">返事を考えています。少し待ってください。</string>
+    <string name="message_typing">考えています…</string>
 
     <string name="setting_dialog_accept">決定</string>
     <string name="setting_dialog_cancel">キャンセル</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -10,6 +10,9 @@
 
     <string name="message_error">エラーが発生しました。ネットワークに繋がっていないかもしれません。</string>
     <string name="message_error_openai">申し訳ありません、GPTモデルは現在利用できません。しばらくは標準モデルとの会話をお楽しみください。</string>
+    <string name="message_error_ai_response">ごめんなさい、うまく答えられませんでした。少し待ってから、もう一度話しかけてください。</string>
+    <string name="message_error_empty_response">ごめんなさい、返す言葉が思いつきませんでした。もう一度話しかけてください。</string>
+    <string name="message_preparing">準備中です。少し待ってから送信してください。</string>
 
     <string name="setting_dialog_accept">決定</string>
     <string name="setting_dialog_cancel">キャンセル</string>
@@ -46,6 +49,7 @@
 
     <string name="copy_message">コピー</string>
     <string name="message_copied">コピーしました</string>
+    <string name="resend_message">もう一度送る</string>
     <string name="report_message">問題を報告</string>
     <string name="report_message_reason">理由</string>
     <string name="report_message_reason_required">理由を入力してください</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,9 @@
 
     <string name="message_error">An error has occurred. Please check your network connection.</string>
     <string name="message_error_openai">Sorry, GPT model is not currently available. The standard model speaks for me.</string>
+    <string name="message_error_ai_response">Sorry, I could not answer. Please wait a moment and talk to me again.</string>
+    <string name="message_error_empty_response">Sorry, I could not think of anything to say. Please talk to me again.</string>
+    <string name="message_preparing">Getting ready. Please wait a moment before sending.</string>
 
     <string name="setting_user_name">Your Name</string>
     <string name="setting_name_title">How can I call you?</string>
@@ -47,6 +50,7 @@
 
     <string name="copy_message">Copy</string>
     <string name="message_copied">Copied</string>
+    <string name="resend_message">Send again</string>
     <string name="report_message">Report</string>
     <string name="report_message_reason">Reason</string>
     <string name="report_message_reason_required">Please enter a reason</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,8 @@
     <string name="message_error_ai_response">Sorry, I could not answer. Please wait a moment and talk to me again.</string>
     <string name="message_error_empty_response">Sorry, I could not think of anything to say. Please talk to me again.</string>
     <string name="message_preparing">Getting ready. Please wait a moment before sending.</string>
+    <string name="message_waiting_response">I\'m thinking about my reply. Please wait a moment.</string>
+    <string name="message_typing">Thinking…</string>
 
     <string name="setting_user_name">Your Name</string>
     <string name="setting_name_title">How can I call you?</string>


### PR DESCRIPTION
Closes #96
Closes #97

AI応答の失敗がユーザーに伝わらない問題（#96）と、応答待ち中の送信がサイレントに破棄される問題（#97）をまとめて修正しました。送信周りの状態管理を一度で整理するため、2つのissueを同じPRで扱っています。

## 変更内容

### #96 AI応答の失敗・遅延がユーザーに伝わらない

- `CoroutineExceptionHandler` でログに落とすだけだった失敗を `runAITask` で受け止め、ミク側の吹き出しとしてエラーを表示する（`showErrorMessage` / `getErrorMessage`）。
- 例外種別で文言を出し分ける。通信エラーはライブラリ独自の例外に包まれるため、`cause` を辿って `IOException` / `OpenAIIOException` / `UnavailableException` を判定する。
- `openAI` を `lateinit` から nullable に変更し、RemoteConfig・Firebase の取得が終わるまでは送信をブロックして「準備中」を通知する（以前は `UninitializedPropertyAccessException` が握り潰されて無反応になっていた）。
- 空応答を失敗として扱い、黙って捨てないようにする。
- 長押しメニューに「もう一度送る」を追加し、応答が返らなかったメッセージを履歴に増やさず再送信できるようにする。
- 広告・支援ダイアログのカウントを `onClick` に移し、再送信や送信されなかったメッセージを数えないようにする。

### #97 応答待ち中の送信がサイレントに破棄される

- `openAITaskJob: Job?` を `isSending: Boolean` に置き換え、判定と更新をメインスレッドに揃えて連続タップの競合を防ぐ（コルーチン内で判定すると両方すり抜ける）。Dialogflow 側にも同じガードを適用し、両モデルで挙動を揃えた。
- `canSendRequest()` を新設し、`onClick` のメッセージ表示より前に判定する。応答待ち中は Toast を出し、入力内容を消さずに return するので打ち直さずに再送信できる。
- 応答待ち中は送信ボタンを無効化し、ミクの吹き出しとしてタイピングインジケータを表示する。この吹き出しは応答待ちの間だけのものなので DB には保存しない。
- `runAITask` の `finally` で `NonCancellable + Dispatchers.Main` を使い、失敗しても応答待ちのまま固まらないよう必ず解除する。

## adb 検証（emulator-5554 / Pixel 9a / Android 16）

`ads` フレーバーで以下を実機（エミュレータ）確認しました。

### 検証済み

| 項目 | 結果 |
| --- | --- |
| 通信を切って送信（Dialogflow） | 送信した吹き出しの直後に、ミクの吹き出しで「An error has occurred. Please check your network connection.」が表示された（`UnavailableException` → 通信エラー分岐） |
| 通信を切って送信（GPT） | 同じくミクの吹き出しでネットワークエラーが表示された（`GenericIOException`） |
| エラー後の再送信 | 長押し →「もう一度送る」。オフラインのままだとユーザーの吹き出しは増えずエラー吹き出しだけが追加され、通信を復旧してから再送信すると通常の応答が表示された |
| 応答待ち中に続けて送信 | 送信ボタンが `enabled=false` になり、2通目は送信されず入力欄に文字列が残ったまま。チャットにも履歴にも2通目は現れなかった |
| 応答待ち中の再送信 | 「返事を考えています。少し待ってください。」の Toast が表示され、リクエストは飛ばなかった |
| タイピングインジケータ | 応答待ち中に「Thinking…」がミクの吹き出しとして表示され、応答／エラー表示時に消えた |
| インジケータが履歴に残らない | アプリを再起動しても「Thinking…」は履歴に存在しなかった（DB 未保存） |
| 起動直後に GPT で送信 | 「準備中」ガードが働き（`OpenAI is not initialized yet.`）、入力内容は保持されメッセージは追加されなかった |
| 正常時の応答（回帰） | Dialogflow・GPT の両方で通常の応答が表示され、インジケータも残らなかった |
| 応答待ち中の画面回転 | `configChanges` により Activity は再生成されず、回転後も応答待ち状態を保ち、応答受信で送信ボタンが再度有効化された（固まらない） |
| 応答待ち中のバックグラウンド遷移 | HOME → 復帰後も応答待ち状態を維持し、応答受信で正常に解除された |
| 広告表示との競合（#95） | 送信回数到達でインタースティシャル（IronSource）が表示され、応答は裏で受信・表示された。広告を閉じた後も送信ボタンは有効で、インジケータの残留もなかった |
| `noAds` フレーバー | 起動・送信・応答までクラッシュなし |

### 未検証

- **空応答時の文言（`message_error_empty_response`）**: OpenAI / Dialogflow に空応答を返させる手段がないため、実機では確認できていません。コード上は `receiveMessage(null)` でエラー表示に落ちることを確認済みです。
- **通信エラー以外の AI エラー文言（`message_error_ai_response`）**: APIキー不正や 5xx を意図的に起こせなかったため未確認です。`getErrorMessage` の else 側に該当します。
