### PR TITLE
外部HTTP通信のURLエンコード・JSON組み立て・タイムアウトを修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Single-module Android app with an activity-centric architecture. Nearly all UI l
 - **Config**: `config/` package — type-safe enums for AI model, font size, language, UI mode; `SharedPreferenceManager` wraps SharedPreferences; `RemoteConfigProvider` wraps Firebase RemoteConfig, which controls feature flags
 - **Data**: Room database (`database/` package) stores chat messages; Firebase Realtime DB stores API keys and credentials at runtime
 - **Ads**: `ads/` package — `AdController` interface in `main`, implementations per flavor
-- **Utilities**: `TranslateUtil` (EN↔JP translation via HTTP), `ReportUtil` (message reporting)
+- **Utilities**: `HttpClientProvider` (the shared HTTP client), `TranslateUtil` (EN↔JP translation), `ReportUtil` (message reporting) — see [Networking](#networking)
 
 ### Configuration System
 
@@ -57,6 +57,21 @@ Blocking I/O must not run on the main thread.
 - Cleanup that has to outlive the Activity runs on `Application.applicationScope` (a process-lifetime `SupervisorJob` + `Dispatchers.IO` scope): `DetectIntent.shutdown()` resets the Dialogflow contexts (a blocking gRPC call) and closes both clients, and does nothing when they were never created.
 - Firebase Realtime Database listeners registered in `setupOpenAI()` / `setupChat()` are kept in fields and removed in `onDestroy()`.
 - Debug builds enable `StrictMode`'s thread policy (`detectAll().penaltyLog()`), so main thread disk/network access is visible in logcat. The app's own code is expected to produce no violations; the IronSource SDK produces several in the `ads` flavor (`IronSource.init()` reads its preferences and files synchronously on the main thread).
+
+### Networking
+
+Translation and message reporting share one Ktor client (`HttpClientProvider`), created lazily with the OkHttp engine. Ktor and that engine are already on the classpath for the OpenAI client, so no dependency is added, and naming the engine explicitly avoids the APK scan that picking one by `ServiceLoader` costs (see [Threading](#threading)). The client sets connect/socket/request timeouts, so a stalled network cannot block a coroutine indefinitely.
+
+Redirects are left to OkHttp (`followRedirects = false` on the Ktor side, `followRedirects(true)` on the engine): both endpoints are Google Apps Script and answer every request — GET and POST alike — with a 302 whose target only accepts GET. Ktor's `HttpRedirect` does not follow redirects for POST at all, and following one with the method preserved returns 405; OkHttp downgrades a 302 to GET as the HTTP spec says.
+
+`TranslateUtil` builds its query with `parameter()`, which encodes the value, and returns `Result<String>`:
+
+- Concatenating the text into the URL broke on `&` (`tea & coffee` reached the endpoint as `tea `), on `#` (everything from it, including `target`, was dropped) and on `+` (decoded as a space). Non-ASCII and spaces happened to survive only because Android's `HttpURLConnection` is backed by OkHttp, which canonicalizes the URL.
+- Returning `getString(R.string.message_error)` as the "translation" made a failure indistinguishable from a result: it was sent to Dialogflow as the user's message, shown as Miku's reply, and stored in the history. `DetectIntent.request()` now unwraps with `getOrThrow()` and lets `MainActivity.runAITask()` show it as an error instead.
+
+`ReportUtil` builds its payload with `JSONObject` and declares `POST` explicitly instead of relying on `doOutput`. String concatenation produced invalid JSON for any name, message or reason containing `"`, `\` or a newline, and Apps Script answers invalid JSON with an error *page* under status 200 — so the report was dropped while the user saw the success toast.
+
+`MainActivity.shouldInterceptRequest()` keeps its own `HttpURLConnection` for the avatar page's assets: `WebView` wants a synchronous `InputStream` that it reads at its own pace, so the connection has to outlive the call and cannot be wrapped in a suspending client.
 
 ### Database
 

--- a/app/src/main/java/com/aqua_ix/youbimiku/DetectIntent.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/DetectIntent.kt
@@ -101,9 +101,15 @@ class DetectIntent(
         }
     }
 
-    private fun request(text: String): String {
+    /**
+     * 翻訳に失敗した場合は例外にする。エラー文言を翻訳結果として扱うと、
+     * ミクの応答として表示されたうえ履歴にも残ってしまうため、
+     * 呼び出し元（[MainActivity]）にエラーとして伝える。
+     */
+    private suspend fun request(text: String): String {
         val shouldTranslate = getLanguage(context).equals(LanguageConfig.LANGUAGE_EN.name)
-        val sendText = if (shouldTranslate) TranslateUtil.translateEnToJa(text) else text
+        val sendText =
+            if (shouldTranslate) TranslateUtil.translateEnToJa(text).getOrThrow() else text
         val detectIntentRequest = DetectIntentRequest.newBuilder()
             .setQueryInput(
                 QueryInput.newBuilder()
@@ -120,7 +126,7 @@ class DetectIntent(
 
         val res = clients.sessions.detectIntent(detectIntentRequest)
         if (shouldTranslate) {
-            return TranslateUtil.translateJaToEn(res.queryResult.fulfillmentText)
+            return TranslateUtil.translateJaToEn(res.queryResult.fulfillmentText).getOrThrow()
         }
 
         Log.d(TAG, "response result : ${res.queryResult}")

--- a/app/src/main/java/com/aqua_ix/youbimiku/HttpClientProvider.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/HttpClientProvider.kt
@@ -1,0 +1,50 @@
+package com.aqua_ix.youbimiku
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.HttpTimeout
+
+/**
+ * アプリのHTTP通信で共有するクライアント。
+ *
+ * 翻訳とメッセージ報告がそれぞれ[java.net.HttpURLConnection]を組み立てていたのをまとめ、
+ * タイムアウトとリダイレクトの扱いを1か所に持たせる。OpenAIのクライアントが使っている
+ * Ktorをそのまま使うため、依存は増やさない。
+ *
+ * 生成には時間がかかるため初回の通信まで遅延させる。通信と合わせて[kotlinx.coroutines.Dispatchers.IO]
+ * の上から使う。プロセスと同じ寿命で使い回すので閉じない。
+ */
+object HttpClientProvider {
+
+    // 応答が返らないまま待ち続けないための上限
+    private const val CONNECT_TIMEOUT_IN_MILLIS = 10_000L
+    private const val SOCKET_TIMEOUT_IN_MILLIS = 15_000L
+    private const val REQUEST_TIMEOUT_IN_MILLIS = 30_000L
+
+    val client: HttpClient by lazy { createClient() }
+
+    private fun createClient(): HttpClient =
+        // エンジンを明示しないとAPKを走査して探すことになり、生成に数百ms余分にかかる
+        HttpClient(OkHttp) {
+            install(HttpTimeout) {
+                connectTimeoutMillis = CONNECT_TIMEOUT_IN_MILLIS
+                socketTimeoutMillis = SOCKET_TIMEOUT_IN_MILLIS
+                requestTimeoutMillis = REQUEST_TIMEOUT_IN_MILLIS
+            }
+
+            // 通信先のGoogle Apps ScriptはGET・POSTのどちらにも302を返し、
+            // リダイレクト先はGETしか受け付けない（POSTのまま追うと405になる）。
+            // KtorのHttpRedirectはGETとHEADしか追わないため、302をGETに落として追う
+            // OkHttp側のリダイレクト処理に任せる。
+            followRedirects = false
+            engine {
+                config {
+                    followRedirects(true)
+                    followSslRedirects(true)
+                }
+            }
+
+            // 成功か失敗かは呼び出し側がステータスコードを見て判断する
+            expectSuccess = false
+        }
+}

--- a/app/src/main/java/com/aqua_ix/youbimiku/ReportUtil.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/ReportUtil.kt
@@ -1,17 +1,30 @@
 package com.aqua_ix.youbimiku
 
 import android.content.Context
+import android.util.Log
 import android.widget.EditText
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.net.HttpURLConnection
-import java.net.URL
+import org.json.JSONObject
 
 object ReportUtil {
+
+    private const val TAG = "ReportUtil"
+
+    private const val FIELD_TIMESTAMP = "timestamp"
+    private const val FIELD_USER_NAME = "userName"
+    private const val FIELD_TEXT = "text"
+    private const val FIELD_REASON = "reason"
 
     fun showReportReasonDialog(
         context: Context,
@@ -50,44 +63,40 @@ object ReportUtil {
         reason: String,
         scope: CoroutineScope
     ) {
+        // 文字列連結では本文の " や \ 、改行でJSONが壊れて送信できず、
+        // 中身次第では他の項目を差し替えられてしまうため、JSONObjectで組み立てる
+        val payload = JSONObject()
+            .put(FIELD_TIMESTAMP, System.currentTimeMillis().toString())
+            .put(FIELD_USER_NAME, userName)
+            .put(FIELD_TEXT, text)
+            .put(FIELD_REASON, reason)
+            .toString()
+
         scope.launch {
-            try {
-                val url = URL(BuildConfig.REPORT_END_POINT)
-                val urlConnection = url.openConnection() as HttpURLConnection
-                urlConnection.setRequestProperty("Content-Type", "application/json")
-                urlConnection.doOutput = true
-
-                val data =
-                    """{"timestamp": "${System.currentTimeMillis()}", "userName": "$userName", "text": "$text", "reason": "$reason"}"""
-                urlConnection.outputStream.use { it.write(data.toByteArray()) }
-
-                val responseCode = urlConnection.responseCode
-                if (responseCode == HttpURLConnection.HTTP_OK) {
-                    withContext(Dispatchers.Main) {
-                        Toast.makeText(
-                            context,
-                            context.getString(R.string.message_reported),
-                            Toast.LENGTH_SHORT
-                        ).show()
-                    }
-                } else {
-                    withContext(Dispatchers.Main) {
-                        Toast.makeText(
-                            context,
-                            context.getString(R.string.message_reported_error),
-                            Toast.LENGTH_SHORT
-                        ).show()
-                    }
-                }
-            } catch (ex: Exception) {
-                withContext(Dispatchers.Main) {
-                    Toast.makeText(
-                        context,
-                        context.getString(R.string.message_reported_error),
-                        Toast.LENGTH_SHORT
-                    ).show()
-                }
+            val isReported = send(payload)
+            withContext(Dispatchers.Main) {
+                val message =
+                    if (isReported) R.string.message_reported else R.string.message_reported_error
+                Toast.makeText(context, context.getString(message), Toast.LENGTH_SHORT).show()
             }
         }
+    }
+
+    private suspend fun send(payload: String): Boolean = try {
+        // doOutputによる暗黙のPOSTに頼らず、メソッドを明示する
+        val response = HttpClientProvider.client.post(BuildConfig.REPORT_END_POINT) {
+            contentType(ContentType.Application.Json)
+            setBody(payload)
+        }
+        val isSuccess = response.status.isSuccess()
+        if (!isSuccess) {
+            Log.e(TAG, "Unexpected status code: ${response.status.value}")
+        }
+        isSuccess
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        Log.e(TAG, "Failed to report the message.", e)
+        false
     }
 }

--- a/app/src/main/java/com/aqua_ix/youbimiku/TranslateUtil.kt
+++ b/app/src/main/java/com/aqua_ix/youbimiku/TranslateUtil.kt
@@ -1,48 +1,50 @@
 package com.aqua_ix.youbimiku
 
-import java.io.BufferedReader
-import java.io.InputStreamReader
-import java.net.HttpURLConnection
-import java.net.URL
+import android.util.Log
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.isSuccess
+import kotlinx.coroutines.CancellationException
+import java.io.IOException
 
-class TranslateUtil {
-    companion object {
-        fun translateEnToJa(text: String): String {
-            try {
-                val url = URL("${BuildConfig.TRANSLATE_END_POINT}?text=$text&target=ja")
-                val urlConnection = url.openConnection() as HttpURLConnection
-                urlConnection.requestMethod = "GET"
-                urlConnection.connect()
+/**
+ * 翻訳APIとのやり取りを行う。
+ *
+ * クエリは[io.ktor.client.request.parameter]がエンコードするため、`&` `#` `+` `%` や
+ * 空白、改行、絵文字、日本語を含む文章でも壊れない（文字列連結では
+ * パラメータが分断されたり、URLごと拒否されたりしていた）。
+ *
+ * 失敗は[Result]で返す。エラー文言を翻訳結果として返すと呼び出し側が成功と区別できず、
+ * ミクの発言としてそのまま表示されてしまうため。
+ */
+object TranslateUtil {
 
-                val sb = StringBuilder()
-                val br = BufferedReader(InputStreamReader(urlConnection.inputStream))
-                br.readLines().forEach {
-                    sb.append(it)
-                }
-                br.close()
-                return sb.toString()
-            } catch (ex: Exception) {
-                return Application.instance.getString(R.string.message_error)
-            }
+    private const val TAG = "TranslateUtil"
+
+    private const val PARAM_TEXT = "text"
+    private const val PARAM_TARGET = "target"
+    private const val TARGET_JA = "ja"
+    private const val TARGET_EN = "en"
+
+    suspend fun translateEnToJa(text: String): Result<String> = translate(text, TARGET_JA)
+
+    suspend fun translateJaToEn(text: String): Result<String> = translate(text, TARGET_EN)
+
+    private suspend fun translate(text: String, target: String): Result<String> = try {
+        val response = HttpClientProvider.client.get(BuildConfig.TRANSLATE_END_POINT) {
+            parameter(PARAM_TEXT, text)
+            parameter(PARAM_TARGET, target)
         }
-
-        fun translateJaToEn(text: String): String {
-            try {
-                val url = URL("${BuildConfig.TRANSLATE_END_POINT}?text=$text&target=en")
-                val urlConnection = url.openConnection() as HttpURLConnection
-                urlConnection.requestMethod = "GET"
-                urlConnection.connect()
-
-                val sb = StringBuilder()
-                val br = BufferedReader(InputStreamReader(urlConnection.inputStream))
-                br.readLines().forEach {
-                    sb.append(it)
-                }
-                br.close()
-                return sb.toString()
-            } catch (ex: Exception) {
-                return Application.instance.getString(R.string.message_error)
-            }
+        if (!response.status.isSuccess()) {
+            throw IOException("Unexpected status code: ${response.status.value}")
         }
+        // 前後の改行は吹き出しの余白になるだけなので落とす
+        Result.success(response.bodyAsText().trim())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        Log.e(TAG, "Failed to translate into $target.", e)
+        Result.failure(e)
     }
 }


### PR DESCRIPTION
Closes #99

外部HTTP通信（翻訳・メッセージ報告）の実装を見直しました。URLエンコード漏れ、JSONの手組み、POST未指定、タイムアウト未設定、翻訳失敗が「翻訳結果」として画面に出る問題をまとめて直しています。

## 変更内容

### 1. 共通HTTPクライアントの追加（`HttpClientProvider`）

翻訳と報告がそれぞれ `HttpURLConnection` を組み立てていたのを、Ktorクライアント1つに統一しました。

- **新規依存はありません。** Ktorとそのエンジン（`ktor-client-okhttp`）はOpenAIクライアント用に既に `build.gradle.kts` で宣言済みです。エンジンを `HttpClient(OkHttp)` と明示しているので、`ServiceLoader` でAPKを走査するコスト（#111 でOpenAIクライアントについて計測した約400ms）はかかりません
- connect 10s / socket 15s / request 30s のタイムアウトを設定
- **リダイレクトはOkHttp側に任せています**（Ktor側 `followRedirects = false`、エンジン側 `followRedirects(true)`）。通信先のGoogle Apps ScriptはGET・POSTのどちらにも302を返し、リダイレクト先はGETしか受け付けません。KtorのHttpRedirectはGET/HEADしか追わないためPOSTでは302がそのまま返り、`checkHttpMethod = false` でメソッドを保ったまま追うと405になります（curlで確認済み）。OkHttpはHTTPの仕様どおり302をGETに落として追うため、従来の `HttpURLConnection` と同じ挙動になります

### 2. 翻訳クエリのエンコードと `Result<String>` 化（`TranslateUtil` / `DetectIntent`）

- クエリを `parameter()` で組み立てるようにしました
- 戻り値を `Result<String>` にし、`DetectIntent.request()` で `getOrThrow()` するようにしました。失敗は `MainActivity.runAITask()`（#109）がエラーとして表示します
- `Application.instance` への依存が不要になりました

### 3. 報告ペイロードの `JSONObject` 化とPOSTの明示（`ReportUtil`）

- `JSONObject` で組み立てるようにしました
- `requestMethod` を明示（従来は `doOutput = true` による暗黙のPOST）
- Toast表示の分岐を1か所にまとめました

`shouldInterceptRequest()` の `HttpURLConnection` は**触っていません**。WebViewは同期的な `InputStream` を自分のペースで読むため、接続が呼び出しより長生きする必要があり、suspendするクライアントには置き換えられないからです（理由をCLAUDE.mdに追記しました）。

## 壊れた入力での修正前後の挙動

### 翻訳（英語ロケール・標準モデル、エミュレータ実機）

`TranslateUtil` に一時ログを仕込んで、エンドポイントに実際に届いたクエリと結果を記録して比較しました。

| 入力 | 修正前（届いたクエリ → 結果） | 修正後（届いたクエリ → 結果） |
| --- | --- | --- |
| `tea & coffee` | `text=tea & coffee&target=ja` → **`お茶 `**（`& coffee` が別パラメータとして落ちる） | `text=tea+%26+coffee` → **`紅茶とコーヒー`** |
| `issue #99 is fixed` | `text=issue ` （`#` 以降が全部消え `target` も失われる）→ **`問題 `** | `text=issue+%2399+is+fixed` → **`問題番号99は修正されました`** |
| `1 + 1 = 2` | `text=1 + 1 = 2` → **`1 1 = 2`**（`+` が空白に化ける） | `text=1+%2B+1+%3D+2` → **`1 + 1 = 2`** |
| `50% off` | `50%オフ`（もともと通る） | `text=50%25++off` → `50%オフ` |
| 改行入り `good morning\nand good night` | （未計測） | `text=good+morning%0Aand+good+night` → `おはようございます\nそしておやすみなさい`（改行も保持） |
| 絵文字 `happy😍🥳` | （日本語・絵文字はAndroidの `HttpURLConnection` がOkHttp実装のため元々通っていました） | `%F0%9F%98%8D%F0%9F%A5%B3` → `幸せ😍🥳` |
| `&` `#` `+` を含む248文字 | （先頭の `&` で切れる） | 全文が正しく翻訳される |

補足: 空白・日本語・絵文字は、Androidの `HttpURLConnection` がOkHttp実装でURLを正規化するため修正前も通っていました。壊れていたのは区切り文字として意味を持つ `&` `#` と、空白に解釈される `+` です（デスクトップのJVMでは日本語のURLは400になります）。

### メッセージ報告

理由に `say "hi" \o/` + 改行 + `second line` を入力して比較しました。

**修正前**（送信されたペイロード）:

```
{"timestamp": "...", "userName": "Tester", "text": "...", "reason": "say "hi" \o/
second line"}
```

不正なJSONです。エンドポイントに同じものをcurlで投げるとApps Scriptのエラーページ（HTML）が**ステータス200**で返り、記録されません。修正前のコードはステータスコードだけを見ていたため、**失敗しているのに「報告しました」トーストが出ます**。

**修正後**:

```
{"timestamp":"...","userName":"Tester","text":"...","reason":"say \"hi\" \\o\/\nsecond line"}
```

`method=POST status=200 body={"status":"success"}` を確認しました（正常に記録される応答）。

### 翻訳失敗の扱い

翻訳だけを失敗させるため、`TranslateUtil` に `IOException` を注入したビルドで比較しました。

- **修正前**: ログに `response: An error has occurred. Please check your network connection.` と出て、エラー文がミクの発言として表示され、**履歴（DB）にも保存されます**（`MessageEntity` に `isRightMessage=0` の行として残ることを確認）
- **修正後**: `AI request error` としてエラー表示され、**履歴には保存されません**（再起動後のDBに該当行がないことを確認）

## adb検証（emulator-5554 / Android 16 / 1080x2424）

受け入れ条件:

- [x] `&` や改行を含む文章で翻訳が正しく動作する → 上表のとおり
- [x] `"` や改行を含むメッセージのレポートが成功する → `{"status":"success"}` を確認
- [x] タイムアウトが設定され、通信不良時に長時間ブロックしない → 到達しないプロキシを設定して送信し、**10.2秒後**に `ConnectTimeoutException` が出て「ネットワークを確認してください」が表示されることを確認（ハングもANRもなし）
- [x] 翻訳失敗がエラーとして呼び出し側に伝わる → 上記のとおり

回帰確認:

- [x] 標準モデル（DialogFlow）: 英語モード（翻訳あり）・日本語モード（翻訳なし。`TranslateUtil` が呼ばれないことをログで確認）ともに応答を取得
- [x] GPTモデル: 応答を取得（翻訳は経由しない）
- [x] 応答待ち表示（Thinking…）、履歴表示・復元
- [x] 通信断（`svc wifi disable` / `svc data disable`）: クラッシュせず #96/#109 のエラー表示が機能。検証後にネットワーク復旧済み
- [x] アバターモード: 3D表示、ページ内XHR、戻るキーでチャットモードに復帰（`shouldInterceptRequest` は未変更）
- [x] 広告: バナー初期化、30通目でインタースティシャル表示 → 閉じて `onAdClosed` まで確認
- [x] `noAds` フレーバー: クラッシュなし、標準モデル・GPTモデルともに動作
- [x] StrictMode違反: `ads` は21件（すべてIronSource SDK由来、スタックトレースで確認）で #98/#101 の状態から増加なし。`noAds` は0件

未検証:

- 実機（物理端末）での確認はしていません（エミュレータのみ）
- 数千文字級の長文は、`adb shell input text` が約50文字で切れるため分割入力で248文字までを確認しました。それ以上の長さはcurlで約1800文字まで正常応答を確認しています

## 備考

- 一時的に仕込んだ検証用ログはコミット前に削除しています
- Apps Scriptはスクリプト側のエラーもステータス200で返すため、`{"status":"success"}` を見ないと本当に記録されたかは分かりません。応答本文の判定はスクリプトの応答形式への依存が増えるので、このPRではステータスコード判定のままにしています（必要なら別issueで）
- 失敗時に例外をログ出力していますが、Ktorのタイムアウト例外はメッセージにエンドポイントURL（secrets管理）を含みます。ログ整理は #102 の範囲なので、ここでは既存の `MainActivity` の失敗ログと同じ扱いにしています
